### PR TITLE
Fix duplicated class names

### DIFF
--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -27,5 +27,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.0"
+  version = "1.0.1"
 }

--- a/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
+++ b/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
@@ -222,13 +222,14 @@ function isClassLike(schema: JsonSchema.Schema): Boolean =
 /// Try to use the parent property's name as part of the class name in case of conflict.
 /// If already at the root, add a number at the end.
 local function determineTypeName(path: List<String>, candidateName: String, existingTypeNames: Set<Type>, index: Int): Type =
-  if (existingTypeNames.contains(utils.pascalCase(candidateName)))
-    if (path.isEmpty)
-      determineTypeName(path, candidateName + index.toString(), existingTypeNames, index + 1)
+  let (candidateType = new Type { name = utils.pascalCase(candidateName); moduleName = module.moduleName })
+    if (existingTypeNames.contains(candidateType))
+      if (path.isEmpty)
+        determineTypeName(path, candidateName + index.toString(), existingTypeNames, index + 1)
+      else
+        determineTypeName(path.dropLast(1), utils.pascalCase(path.last.capitalize()) + utils.pascalCase(candidateName), existingTypeNames, index)
     else
-      determineTypeName(path.dropLast(1), utils.pascalCase(path.last.capitalize()) + utils.pascalCase(candidateName), existingTypeNames, index)
-  else
-    new { name = utils.pascalCase(candidateName); moduleName = module.moduleName }
+      candidateType 
 
 /// The schemas that should be rendered as classes.
 ///
@@ -240,7 +241,7 @@ local classSchemas: Type.TypeNames =
       .fold(Map(), (accumulator: Type.TypeNames, pair) ->
         let (path = pair.first)
         let (schema = pair.second)
-        let (typeName = determineTypeName(path, path.lastOrNull?.capitalize() ?? "Item", accumulator.values.toSet(), 0))
+        let (typeName = determineTypeName(path.dropLast(1), path.lastOrNull?.capitalize() ?? "Item", accumulator.values.toSet(), 0))
           accumulator.put(schema, typeName)
       )
 

--- a/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl
+++ b/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl
@@ -211,6 +211,46 @@ examples {
     }
     new ModuleGenerator { rootSchema = schema ; moduleName = "com.apple.Example" }.moduleNode.render("")
   }
+  ["classes within definitions properties"] {
+     local schema: JsonSchema = new {
+      local self = this
+      properties {
+        ["foo"] {
+          $ref = "#/definitions/foo"
+          $$baseSchema = self
+        }
+        ["bar"] {
+          $ref = "#/definitions/bar"
+          $$baseSchema = self
+        }
+      }
+      definitions {
+        ["foo"] {
+          properties {
+            ["waldo"] {
+              properties {
+                ["qux"] {
+                  type = "string"
+                }
+              }
+            }
+          }
+        }
+        ["bar"] {
+          properties {
+            ["waldo"] {
+              properties {
+                ["corge"] {
+                  type = "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    new ModuleGenerator { rootSchema = schema ; moduleName = "com.apple.Example" }.moduleNode.render("")
+  }
   ["classes from inline positions"] {
     local schema: JsonSchema = new {
       local self = this

--- a/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl-expected.pcf
@@ -163,6 +163,35 @@ examples {
 
     """
   }
+  ["classes within definitions properties"] {
+    """
+    /// This module was generated from JSON Schema from <>.
+    ///
+    /// WARN: unable to determine module-level properties on the root schema.
+    module com.apple.Example
+    
+    foo: Foo?
+    
+    bar: Bar?
+    
+    class Foo {
+      waldo: Waldo?
+    }
+    
+    class Waldo {
+      qux: String?
+    }
+    
+    class Bar {
+      waldo: BarWaldo?
+    }
+    
+    class BarWaldo {
+      corge: String?
+    }
+
+    """
+  }
   ["classes from inline positions"] {
     """
     /// This module was generated from JSON Schema from <>.


### PR DESCRIPTION
This PR fixes a bug that leads to the generation of duplicated codes when multiple JSON schema definitions share the same property name. As a result, the code generation process produces multiple classes whit the same name.