### PR TITLE
Remove unnecessary `= Undefined()`

### DIFF
--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -27,5 +27,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }

--- a/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
+++ b/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
@@ -19,7 +19,6 @@
 module org.json_schema.contrib.internal.ModuleGenerator
 
 import "@syntax/TypeNode.pkl"
-import "@syntax/ExpressionNode.pkl"
 import "@syntax/ClassNode.pkl"
 import "@syntax/ClassOrModuleNode.pkl"
 import "@syntax/TypeAliasNode.pkl"
@@ -162,22 +161,6 @@ local function generateClassBody(
               else if (underlyingType is TypeNode.NullableTypeNode) underlyingType
               else new TypeNode.NullableTypeNode { typeNode = underlyingType }
           }
-          defaultValue =
-            if (typeAnnotation.type is TypeNode.UnionTypeNode
-              && (typeAnnotation.type as TypeNode.UnionTypeNode).members[0] is TypeNode.StringLiteralTypeNode
-            )
-              // If the first member is a string literal type, explicitly set the default to Undefined().
-              // We need to do this because the implicit default of a union type is the default of the first member.
-              // However, this is an incorrect way to represent enums in JSON Schema, because there should be no
-              // bias towards any of the values.
-              new ExpressionNode.MemberAccessExpressionNode {
-                identifier {
-                  value = "Undefined"
-                }
-                // empty arguments makes this a function call
-                arguments {}
-              }
-            else null
         }
       }
     }

--- a/packages/pkl.experimental.syntax/ExpressionNode.pkl
+++ b/packages/pkl.experimental.syntax/ExpressionNode.pkl
@@ -48,7 +48,7 @@ class BinaryOperatorExpressionNode extends ExpressionNode {
 
   local function hasHigherPrecedence(a: String, b: String) = precedences[a] >= precedences[b]
 
-  operator: operators.BinaryOperator = Undefined()
+  operator: operators.BinaryOperator
 
   /// The right hand side of the expression
   lhs: ExpressionNode
@@ -71,14 +71,14 @@ class BinaryOperatorExpressionNode extends ExpressionNode {
 }
 
 class BuiltInKeywordExpressionNode extends ExpressionNode {
-  keyword: "this"|"outer"|"module" = Undefined()
+  keyword: "this"|"outer"|"module"
 
   function render(_) = keyword
 }
 
 /// Unary operators in the prefix position: "!" and "-".
 class PrefixOperatorExpressionNode extends ExpressionNode {
-  operator: operators.PrefixOperator = Undefined()
+  operator: operators.PrefixOperator
 
   expression: ExpressionNode
 
@@ -90,7 +90,7 @@ class PrefixOperatorExpressionNode extends ExpressionNode {
 
 /// Unary operators in the postfix position: "!!"
 class PostfixOperatorExpressionNode extends ExpressionNode {
-  operator: operators.PostfixOperator = Undefined()
+  operator: operators.PostfixOperator
 
   expression: ExpressionNode
 

--- a/packages/pkl.experimental.syntax/ModuleNode.pkl
+++ b/packages/pkl.experimental.syntax/ModuleNode.pkl
@@ -88,7 +88,7 @@ class ModuleHeaderNode extends Node {
 }
 
 class ModuleExtendsOrAmendsClauseNode extends Node {
-  type: "extends"|"amends" = Undefined()
+  type: "extends"|"amends"
   extendedModule: String
   function render() =
     """

--- a/packages/pkl.experimental.syntax/PklProject
+++ b/packages/pkl.experimental.syntax/PklProject
@@ -17,6 +17,6 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.0"
+  version = "1.0.1"
   apiTests = import*("tests/*.pkl").keys.toListing()
 }

--- a/packages/pkl.experimental.syntax/TypeNode.pkl
+++ b/packages/pkl.experimental.syntax/TypeNode.pkl
@@ -29,7 +29,7 @@ class NullableTypeNode extends TypeNode {
 }
 
 class BuiltInTypeNode extends TypeNode {
-  type: "unknown"|"nothing"|"module" = Undefined()
+  type: "unknown"|"nothing"|"module"
   function render(_) = type
 }
 


### PR DESCRIPTION
These are vestiges from old Pkl when this actually mattered.