### PR TITLE
[pkl.experimental.deepToTyped] Support types containing Any

### DIFF
--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -100,6 +100,8 @@ hidden classHandlers: Mapping<Class, (List<reflect.Type>, Any) -> Any|Conversion
 
   [Boolean] = (_, value) ->
     if (value is Boolean) value else Unexpected("Boolean", value.getClass().simpleName)
+
+  [Any] = (_, value) -> value
 }
 
 local function applyClass(type: reflect.Class, typeArguments: List<reflect.Type>, value: Any): Any|ConversionFailure =

--- a/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
@@ -143,6 +143,10 @@ local class Storage {
   size: DataSize
 }
 
+local class LooselyTyped {
+  anything: Any
+}
+
 facts {
   ["Basic types"] {
     t.apply(Int, 1) == 1
@@ -295,5 +299,23 @@ facts {
         [DataSize] = (_, value) -> (value as Int).toDataSize("b")
       }
     }.apply(Storage, value) == expectedResult
+  }
+
+  ["Supports types containing Any"] {
+    local looselyTypedIntExpected: LooselyTyped = new {
+      anything = 0
+    }
+    local looselyTypedInt = new {
+      anything = 0
+    }
+    t.apply(LooselyTyped, looselyTypedInt) == looselyTypedIntExpected
+
+    local looselyTypedStringExpected: LooselyTyped = new {
+      anything = "anything"
+    }
+    local looselyTypedString = new {
+      anything = "anything"
+    }
+    t.apply(LooselyTyped, looselyTypedString) == looselyTypedStringExpected
   }
 }


### PR DESCRIPTION
It seems reasonable that deepToTyped should support a type explicitly containing `Any`. Ran into this trying to use `k8s.contrib.crd`: https://github.com/apple/pkl-pantry/issues/24 