### PR TITLE
Fix package versions

### DIFF
--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -29,7 +29,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.2",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema@1": {

--- a/packages/pkl.experimental.syntax/PklProject
+++ b/packages/pkl.experimental.syntax/PklProject
@@ -17,6 +17,6 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
   apiTests = import*("tests/*.pkl").keys.toListing()
 }


### PR DESCRIPTION
Looks like we forgot to bump versions for packages k8s.contrib.crd and pkl.experimental.syntax