### PR TITLE
[pkl.experimental.deepToTyped] Support types containing Any

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -21,6 +21,7 @@ amends "../basePklProject.pkl"
 dependencies {
   ["jsonschema"] = import("../org.json_schema/PklProject")
   ["jsonschema.contrib"] = import("../org.json_schema.contrib/PklProject")
+  ["deepToTyped"] = import("../pkl.experimental.deepToTyped/PklProject")
 
   ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1" }
 
@@ -28,9 +29,8 @@ dependencies {
   // version bumps here.
   ["uri"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.0" }
   ["syntax"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.0" }
-  ["deepToTyped"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.0" }
 }
 
 package {
-  version = "1.0.0"
+  version = "1.0.1"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -1,13 +1,6 @@
 {
   "schemaVersion": 1,
   "resolvedDependencies": {
-    "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
-      "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.0",
-      "checksums": {
-        "sha256": "ee26debba2f6f4ac25ebc13145ea41f0af217d59fce3c26f6cd63ce146d7b2e7"
-      }
-    },
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
       "type": "remote",
       "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1",
@@ -29,9 +22,14 @@
         "sha256": "12a42da6a2933a802cc79cea7f5541513b5106070ca5f1236009ebefeb3d81b3"
       }
     },
+    "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
+      "type": "local",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.1",
+      "path": "../pkl.experimental.deepToTyped"
+    },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.1",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.0"
+  version = "1.0.1"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -100,6 +100,8 @@ hidden classHandlers: Mapping<Class, (List<reflect.Type>, Any) -> Any|Conversion
 
   [Boolean] = (_, value) ->
     if (value is Boolean) value else Unexpected("Boolean", value.getClass().simpleName)
+
+  [Any] = (_, value) -> value
 }
 
 local function applyClass(type: reflect.Class, typeArguments: List<reflect.Type>, value: Any): Any|ConversionFailure =

--- a/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
@@ -143,6 +143,10 @@ local class Storage {
   size: DataSize
 }
 
+local class LooselyTyped {
+  anything: Any
+}
+
 facts {
   ["Basic types"] {
     t.apply(Int, 1) == 1
@@ -295,5 +299,23 @@ facts {
         [DataSize] = (_, value) -> (value as Int).toDataSize("b")
       }
     }.apply(Storage, value) == expectedResult
+  }
+
+  ["Supports types containing Any"] {
+    local looselyTypedIntExpected: LooselyTyped = new {
+      anything = 0
+    }
+    local looselyTypedInt = new {
+      anything = 0
+    }
+    t.apply(LooselyTyped, looselyTypedInt) == looselyTypedIntExpected
+
+    local looselyTypedStringExpected: LooselyTyped = new {
+      anything = "anything"
+    }
+    local looselyTypedString = new {
+      anything = "anything"
+    }
+    t.apply(LooselyTyped, looselyTypedString) == looselyTypedStringExpected
   }
 }


### PR DESCRIPTION
Bump versions, and change k8s.contrib.crd to depend on local package.

Closes #25 
