### PR TITLE
[CircleCI] Add support for top-level executors

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -292,7 +292,7 @@ class ScheduleTriggerFilter {
 
 class ScheduleTriggerFilterBranches {
   /// Either a single branch specifier, or a list of branch specifiers
-  only: * Listing<String>|String
+  only: *Listing<String>|String
 
   /// Either a single branch specifier, or a list of branch specifiers
   ignore: (*Listing<String>|String)?
@@ -300,7 +300,7 @@ class ScheduleTriggerFilterBranches {
 
 class Workflow {
   /// A job can have the keys `requires`, `name`, `context`, `type`, and `filters`.
-  jobs: Listing<* Mapping<String, WorkflowJob>(length == 1)|String>(!isEmpty)
+  jobs: Listing<*Mapping<String, WorkflowJob>(length == 1)|String>(!isEmpty)
 
   /// Specifies which triggers will cause this workflow to be executed.
   ///

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -34,6 +34,13 @@ setup: Boolean?
 /// See the [Creating Orbs](https://circleci.com/docs/creating-orbs/) documentation for details.
 orbs: Mapping<String, Orb|String>?
 
+/// Executors define the execution environment in which the steps of a job will be run,
+/// allowing you to reuse a single executor definition across multiple jobs.
+/// See [executors in the CircleCI documentation](https://circleci.com/docs/configuration-reference/#executors).
+/// Also see [Using Workspaces to Share Data between Jobs](https://circleci.com/docs/workspaces/) for information on
+/// how to use executors to share state between jobs.
+executors: Mapping<String, Executor>?
+
 /// A command defines a sequence of steps as a map to be executed in a job, enabling you to reuse
 /// a single command definition across multiple jobs.
 ///
@@ -85,6 +92,31 @@ class Orb {
   jobs: Mapping<String, Job>?
 }
 
+class Executor {
+  /// Which resource class to use which further determines the amount of CPU and RAM allocated to each container in a
+  /// job.
+  resource_class: ResourceClass?
+
+  /// Shell to use for execution command in all steps.
+  /// Can be overridden by shell in each step (default: See [Default Shell Options](https://circleci.com/docs/configuration-reference/#default-shell-options))
+  shell: String?
+
+  /// In which directory to run the steps. Will be interpreted as an absolute path.
+  working_directory: String?
+
+  /// A map of environment variable names and values.
+  environment: Mapping<String, String>?
+
+  /// Options for [docker executor](https://circleci.com/docs/configuration-reference/#docker)
+  docker: Listing<DockerImage>(!isEmpty)?(onlyOneSet(List(this, macos, machine)))
+
+  /// Options for [macOS executor](https://circleci.com/docs/configuration-reference/#macos)
+  macos: MacOSExecutor?
+
+  /// Options for [machine executor](https://circleci.com/docs/configuration-reference/#machine)
+  machine: Machine?
+}
+
 class Job {
   /// Shell to use for execution command in all steps.
   ///
@@ -93,6 +125,12 @@ class Job {
 
   /// A list of [steps](https://circleci.com/docs/configuration-reference/#steps) to be performed
   steps: Listing<Step>(!isEmpty)
+
+  /// A pre-defined executor from the defined executors or orbs in which to execute this job. Can be used to share
+  /// data between jobs.
+  /// See [Using Workspaces to Share Data between Jobs](https://circleci.com/docs/workspaces/) for information on how to
+  /// use executors to share state between jobs.
+  executor: String?
 
   /// In which directory to run the steps.
   ///
@@ -199,14 +237,14 @@ class DockerImage {
   /// The command used as executable when launching the container.
   ///
   /// [entrypoint] overrides the image’s `ENTRYPOINT`
-  entrypoint: (*Listing<String>|String)?
+  entrypoint: (* Listing<String>|String)?
 
   /// The command used as pid 1 (or args for entrypoint) when launching the container.
   ///
   /// [command] overrides the image’s `COMMAND`.
   /// It will be used as arguments to the image `ENTRYPOINT` if it has one, or as the executable
   /// if the image has no `ENTRYPOINT`.
-  command: (*Listing<String>|String)?
+  command: (* Listing<String>|String)?
 
   /// Which user to run commands as within the Docker container
   user: String?
@@ -254,24 +292,24 @@ class ScheduleTriggerFilter {
 
 class ScheduleTriggerFilterBranches {
   /// Either a single branch specifier, or a list of branch specifiers
-  only: *Listing<String>|String
+  only: * Listing<String>|String
 
   /// Either a single branch specifier, or a list of branch specifiers
-  ignore: (*Listing<String>|String)?
+  ignore: (* Listing<String>|String)?
 }
 
 class Workflow {
   /// A job can have the keys `requires`, `name`, `context`, `type`, and `filters`.
-  jobs: Listing<*Mapping<String, WorkflowJob>(length == 1)|String>(!isEmpty)
+  jobs: Listing<* Mapping<String, WorkflowJob>(length == 1)|String>(!isEmpty)
 
   /// Specifies which triggers will cause this workflow to be executed.
   ///
   /// Default behavior is to trigger the workflow when pushing to a branch
   triggers: Listing<ScheduleTrigger>?
 
-  `when`: (*LogicStatement|Boolean|String)?
+  `when`: (* LogicStatement|Boolean|String)?
 
-  `unless`: (*LogicStatement|Boolean|String)?
+  `unless`: (* LogicStatement|Boolean|String)?
 }
 
 class WorkflowJob {
@@ -301,7 +339,7 @@ class WorkflowJob {
   /// Each context name must be unique.
   /// If using CircleCI Server, only a single Context per workflow is supported.
   /// Note: A maximum of 100 unique contexts across all workflows is allowed
-  context: (*Listing<String>|String)?
+  context: (* Listing<String>|String)?
 
   /// A job may have a type of `approval` indicating it must be manually approved before downstream
   /// jobs may proceed.
@@ -510,7 +548,7 @@ class WhenStep {
   fixed hidden __name__ = "when"
 
   /// The logic statement that determines whether to execute.
-  condition: (*LogicStatement|Boolean|String)?
+  condition: (* LogicStatement|Boolean|String)?
 
   /// A list of steps to execute when the condition is true
   steps: Listing<AbstractStep|SimpleStepName>?
@@ -527,7 +565,7 @@ class UnlessStep {
   fixed hidden __name__ = "unless"
 
   /// The logic statement that determines whether to execute.
-  condition: (*LogicStatement|Boolean|String)?
+  condition: (* LogicStatement|Boolean|String)?
 
   /// A list of steps to execute when the condition is true
   steps: Listing<AbstractStep|SimpleStepName>?
@@ -598,13 +636,13 @@ class StoreArtifacts extends AbstractStep {
 /// before the workflow is run.
 class LogicStatement {
   /// True if all arguments are truthy.
-  and: Listing<*LogicStatement|Boolean|String>?(onlyOneSet(List(this, or, not, equal, matches)))
+  and: Listing<* LogicStatement|Boolean|String>?(onlyOneSet(List(this, or, not, equal, matches)))
 
   /// True if any arguments are truthy.
-  or: Listing<*LogicStatement|Boolean|String>?
+  or: Listing<* LogicStatement|Boolean|String>?
 
   /// True if the argument is not truthy.
-  not: (*LogicStatement|Boolean|String)?
+  not: (* LogicStatement|Boolean|String)?
 
   /// True if all arguments evaluate to equal values.
   equal: Listing<Boolean|String|Number>?

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -237,14 +237,14 @@ class DockerImage {
   /// The command used as executable when launching the container.
   ///
   /// [entrypoint] overrides the image’s `ENTRYPOINT`
-  entrypoint: (* Listing<String>|String)?
+  entrypoint: (*Listing<String>|String)?
 
   /// The command used as pid 1 (or args for entrypoint) when launching the container.
   ///
   /// [command] overrides the image’s `COMMAND`.
   /// It will be used as arguments to the image `ENTRYPOINT` if it has one, or as the executable
   /// if the image has no `ENTRYPOINT`.
-  command: (* Listing<String>|String)?
+  command: (*Listing<String>|String)?
 
   /// Which user to run commands as within the Docker container
   user: String?
@@ -295,7 +295,7 @@ class ScheduleTriggerFilterBranches {
   only: * Listing<String>|String
 
   /// Either a single branch specifier, or a list of branch specifiers
-  ignore: (* Listing<String>|String)?
+  ignore: (*Listing<String>|String)?
 }
 
 class Workflow {
@@ -307,9 +307,9 @@ class Workflow {
   /// Default behavior is to trigger the workflow when pushing to a branch
   triggers: Listing<ScheduleTrigger>?
 
-  `when`: (* LogicStatement|Boolean|String)?
+  `when`: (*LogicStatement|Boolean|String)?
 
-  `unless`: (* LogicStatement|Boolean|String)?
+  `unless`: (*LogicStatement|Boolean|String)?
 }
 
 class WorkflowJob {
@@ -339,7 +339,7 @@ class WorkflowJob {
   /// Each context name must be unique.
   /// If using CircleCI Server, only a single Context per workflow is supported.
   /// Note: A maximum of 100 unique contexts across all workflows is allowed
-  context: (* Listing<String>|String)?
+  context: (*Listing<String>|String)?
 
   /// A job may have a type of `approval` indicating it must be manually approved before downstream
   /// jobs may proceed.
@@ -548,7 +548,7 @@ class WhenStep {
   fixed hidden __name__ = "when"
 
   /// The logic statement that determines whether to execute.
-  condition: (* LogicStatement|Boolean|String)?
+  condition: (*LogicStatement|Boolean|String)?
 
   /// A list of steps to execute when the condition is true
   steps: Listing<AbstractStep|SimpleStepName>?
@@ -565,7 +565,7 @@ class UnlessStep {
   fixed hidden __name__ = "unless"
 
   /// The logic statement that determines whether to execute.
-  condition: (* LogicStatement|Boolean|String)?
+  condition: (*LogicStatement|Boolean|String)?
 
   /// A list of steps to execute when the condition is true
   steps: Listing<AbstractStep|SimpleStepName>?
@@ -636,13 +636,13 @@ class StoreArtifacts extends AbstractStep {
 /// before the workflow is run.
 class LogicStatement {
   /// True if all arguments are truthy.
-  and: Listing<* LogicStatement|Boolean|String>?(onlyOneSet(List(this, or, not, equal, matches)))
+  and: Listing<*LogicStatement|Boolean|String>?(onlyOneSet(List(this, or, not, equal, matches)))
 
   /// True if any arguments are truthy.
-  or: Listing<* LogicStatement|Boolean|String>?
+  or: Listing<*LogicStatement|Boolean|String>?
 
   /// True if the argument is not truthy.
-  not: (* LogicStatement|Boolean|String)?
+  not: (*LogicStatement|Boolean|String)?
 
   /// True if all arguments evaluate to equal values.
   equal: Listing<Boolean|String|Number>?

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -36,6 +36,7 @@ orbs: Mapping<String, Orb|String>?
 
 /// Executors define the execution environment in which the steps of a job will be run,
 /// allowing you to reuse a single executor definition across multiple jobs.
+///
 /// See [executors in the CircleCI documentation](https://circleci.com/docs/configuration-reference/#executors).
 /// Also see [Using Workspaces to Share Data between Jobs](https://circleci.com/docs/workspaces/) for information on
 /// how to use executors to share state between jobs.
@@ -126,8 +127,9 @@ class Job {
   /// A list of [steps](https://circleci.com/docs/configuration-reference/#steps) to be performed
   steps: Listing<Step>(!isEmpty)
 
-  /// A pre-defined executor from the defined executors or orbs in which to execute this job. Can be used to share
-  /// data between jobs.
+  /// A pre-defined executor from the defined executors or orbs in which to execute this job.
+  ///
+  /// Can be used to share data between jobs.
   /// See [Using Workspaces to Share Data between Jobs](https://circleci.com/docs/workspaces/) for information on how to
   /// use executors to share state between jobs.
   executor: String?

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -53,7 +53,7 @@ commands: Mapping<String, Command>?
 /// Jobs are specified in the jobs map, see
 /// [Sample config.yml](https://circleci.com/docs/sample-config/) for two examples of a job map.
 /// The name of the job is the key in the map, and the value is a map describing the job.
-jobs: Mapping<String, Job>?
+jobs: Mapping<String(matches(Regex("^[A-Za-z][A-Za-z\\s\\d_-]*$"))), Job>?
 
 /// Used for orchestrating all jobs.
 ///

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.0"
+  version = "1.1.0"
 }


### PR DESCRIPTION
In version 2.1 of the CircleCI configuration you can specify top-level executors to support sharing data between jobs. I didn't see this present in the pkl template, so this PR adds that.