### PR TITLE
Switch to PklCI from commons repo

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-amends ".../pkl-project-commons/packages/pkl.impl.circleci/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.0.2#/PklCI.pkl"
 
 triggerPackageDocsBuild = "main"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ workflows:
     - build:
         requires:
         - hold
-        - pr-approval/authenticate
     when:
       matches:
         value: << pipeline.git.branch >>


### PR DESCRIPTION
Also: this makes our PRB build job not depend on `pr-approval/authenticate`.