### PR TITLE
Prevent Gradle from modifying git config locally

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,12 +111,13 @@ val createPackages = tasks.named("createPackages") {
 val isInCircleCi = System.getenv("CIRCLE_PROJECT_REPONAME") != null
 
 val prepareCiGit by tasks.registering {
-    enabled = isInCircleCi
-    exec {
-        commandLine("git", "config", "user.email", "pkl-oss@groups.apple.com")
-    }
-    exec {
-        commandLine("git", "config", "user.name", "The Pkl Team (automation)")
+    if (isInCircleCi) {
+        exec {
+            commandLine("git", "config", "user.email", "pkl-oss@groups.apple.com")
+        }
+        exec {
+            commandLine("git", "config", "user.name", "The Pkl Team (automation)")
+        }
     }
 }
 


### PR DESCRIPTION
The `exec {}` blocks were still running despite `enabled` being set to false.