### PR TITLE
[pkl.experimental.net] Disallow unicode digits in IPs, ports

### DIFF
--- a/packages/pkl.experimental.net/PklProject
+++ b/packages/pkl.experimental.net/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.0"
+  version = "1.1.1"
 }

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -29,7 +29,23 @@ const hidden decByte: String = #"(25[0-5]|2[0-4]\d|[01]?\d\d?)"#
 // language=RegExp
 const hidden ipv4String = #"(\#(decByte)\.){3}\#(decByte)"#
 // language=RegExp
-const hidden ipv6String = #"((\#(hex){1,4}:){7}\#(hex){1,4}|(\#(hex){1,4}:){1,7}:|(\#(hex){1,4}:){1,6}:\#(hex){1,4}|(\#(hex){1,4}:){1,5}(:\#(hex){1,4}){1,2}|(\#(hex){1,4}:){1,4}(:\#(hex){1,4}){1,3}|(\#(hex){1,4}:){1,3}(:\#(hex){1,4}){1,4}|(\#(hex){1,4}:){1,2}(:\#(hex){1,4}){1,5}|\#(hex){1,4}:((:\#(hex){1,4}){1,6})|:((:\#(hex){1,4}){1,7}|:)|fe80:(:\#(hex){0,4}){0,4}%\#(hex){1,}|::(ffff(:0{1,4}){0,1}:){0,1}(\#(decByte)\.){3,3}\#(decByte)|(\#(hex){1,4}:){1,4}:(\#(decByte)\.){3,3}\#(decByte))"#
+const hidden ipv6String = #"""
+  (?x)
+  (
+    (\#(hex){1,4}:){7}\#(hex){1,4}           # x:x:x:x:x:x:x:x
+  | (\#(hex){1,4}:){1,7}:                    # x:: … x:x:x:x:x:x:x::
+  | (\#(hex){1,4}:){1,6}:\#(hex){1,4}        # x::x … x:x:x:x:x:x::x
+  | (\#(hex){1,4}:){1,5}(:\#(hex){1,4}){1,2} # x::x … x:x:x:x:x::x:x
+  | (\#(hex){1,4}:){1,4}(:\#(hex){1,4}){1,3} # x::x … x:x:x:x::x:x:x
+  | (\#(hex){1,4}:){1,3}(:\#(hex){1,4}){1,4} # x::x … x:x:x::x:x:x:x
+  | (\#(hex){1,4}:){1,2}(:\#(hex){1,4}){1,5} # x::x … x:x::x:x:x:x:x
+  | \#(hex){1,4}:((:\#(hex){1,4}){1,6})      # x::x … x::x:x:x:x:x:x
+  | :((:\#(hex){1,4}){1,7}|:)                # ::x … ::x:x:x:x:x:x:x, ::
+  | fe80:(:\#(hex){0,4}){0,4}%\#(hex){1,}                       # fe80::%d … fe80::x:x:x:x%d
+  | ::(ffff(:0{1,4}){0,1}:){0,1}(\#(decByte)\.){3,3}\#(decByte) # ::d.d.d.d, ::ffff:d.d.d.d, ::ffff:0:d.d.d.d
+  | (\#(hex){1,4}:){1,4}:(\#(decByte)\.){3,3}\#(decByte)        # x::d.d.d.d … x:x:x:x::d.d.d.d
+  )
+  """#
 
 ///	A string that contains a MAC address
 // language=RegExp

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -25,7 +25,7 @@ import "./net.pkl"
 // language=RegExp
 const hidden hex: String = "[0-9a-fA-F]"
 // language=RegExp
-const hidden decByte: String = #"(25[0-5]|2[0-4]\d|[01]?\d\d?)"#
+const hidden decByte: String = #"(25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})"#
 // language=RegExp
 const hidden ipv4String = #"(\#(decByte)\.){3}\#(decByte)"#
 // language=RegExp
@@ -71,17 +71,17 @@ typealias IPv6AddressString = String(matches(Regex(net.ipv6String)))
 
 /// A string that contains an IPv4 address and port.
 // language=RegExp
-typealias IPv4AddressPortString = String(matches(Regex(#"\#(net.ipv4String):\d{1,5}"#)))
+typealias IPv4AddressPortString = String(matches(Regex(#"\#(net.ipv4String):[0-9]{1,5}"#)))
 /// A string that contains an IPv6 address and port.
 // language=RegExp
-typealias IPv6AddressPortString = String(matches(Regex(#"\[\#(net.ipv6String)\]:\d{1,5}"#)))
+typealias IPv6AddressPortString = String(matches(Regex(#"\[\#(net.ipv6String)\]:[0-9]{1,5}"#)))
 
 /// A string that contains an IPv4 address.
 // language=RegExp
-typealias IPv4CIDRString = String(matches(Regex(#"\#(net.ipv4String)/\d{1,2}"#)))
+typealias IPv4CIDRString = String(matches(Regex(#"\#(net.ipv4String)/[0-9]{1,2}"#)))
 /// A string that contains an IPv6 address.
 // language=RegExp
-typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/\d{1,3}"#)))
+typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/[0-9]{1,3}"#)))
 
 /// Creates an [IPAddress] from an [IPAddressString].
 function IP(ip: IPAddressString): IPAddress =

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -186,4 +186,45 @@ facts {
     !("[0.0.0.0]:1" is net.IPv6AddressPortString)
     !("::1:10" is net.IPv6AddressPortString)
   }
+  ["IPv4AddressString can't contain unicode digits"] {
+    // U+FF11 is FULLWIDTH DIGIT ONE
+    !("25\u{FF11}.0.0.0" is net.IPv4AddressString)
+    !("20\u{FF11}.0.0.0" is net.IPv4AddressString)
+    !("2\u{FF11}0.0.0.0" is net.IPv4AddressString)
+    !("10\u{FF11}.0.0.0" is net.IPv4AddressString)
+    !("1\u{FF11}0.0.0.0" is net.IPv4AddressString)
+    !("\u{FF11}00.0.0.0" is net.IPv4AddressString)
+    !("00\u{FF11}.0.0.0" is net.IPv4AddressString)
+    !("0\u{FF11}0.0.0.0" is net.IPv4AddressString)
+    !("0\u{FF11}.0.0.0" is net.IPv4AddressString)
+    !("\u{FF11}0.0.0.0" is net.IPv4AddressString)
+    !("\u{FF11}.0.0.0" is net.IPv4AddressString)
+  }
+  ["IPv6AddressString can't contain unicode digits"] {
+    !("\u{FF11}::" is net.IPv6AddressString)
+    !("fe80::%\u{FF11}" is net.IPv6AddressString)
+    !("::25\u{FF11}.0.0.0" is net.IPv6AddressString)
+    !("::20\u{FF11}.0.0.0" is net.IPv6AddressString)
+    !("::2\u{FF11}0.0.0.0" is net.IPv6AddressString)
+    !("::10\u{FF11}.0.0.0" is net.IPv6AddressString)
+    !("::1\u{FF11}0.0.0.0" is net.IPv6AddressString)
+    !("::\u{FF11}00.0.0.0" is net.IPv6AddressString)
+    !("::00\u{FF11}.0.0.0" is net.IPv6AddressString)
+    !("::0\u{FF11}0.0.0.0" is net.IPv6AddressString)
+    !("::0\u{FF11}.0.0.0" is net.IPv6AddressString)
+    !("::\u{FF11}0.0.0.0" is net.IPv6AddressString)
+    !("::\u{FF11}.0.0.0" is net.IPv6AddressString)
+  }
+  ["IPv4AddressPortString can't contain unicode digits in the port"] {
+    !("127.0.0.1:\u{FF11}" is net.IPAddressPortString)
+  }
+  ["IPv6AddressPortString can't contain unicode digits in the port"] {
+    !("[::1]:\u{FF11}" is net.IPAddressPortString)
+  }
+  ["IPv4CIDRString can't contain unicode digits in the suffix"] {
+    !("10.0.0.0/\u{FF11}" is net.IPv4CIDRString)
+  }
+  ["IPv6CIDRString can't contain unicode digits in the suffix"] {
+    !("::1/\u{FF11}" is net.IPv6CIDRString)
+  }
 }

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -25,4 +25,165 @@ facts {
   ["MACAddress"] {
     net.MACAddress("34:73:5A:FA:AF:22").eui64(baseIP).toString() == "0000:0000:0000:0000:3673:5aff:fefa:af22"
   }
+  ["IPv4AddressString"] {
+    "0.0.0.0" is net.IPv4AddressString
+    "127.0.0.1" is net.IPv4AddressString
+    "1.1.1.1" is net.IPv4AddressString
+    "000.000.000.000" is net.IPv4AddressString
+    "255.255.255.255" is net.IPv4AddressString
+    !("0000.0.0.0" is net.IPv4AddressString)
+    !("256.0.0.0" is net.IPv4AddressString)
+    !("260.0.0.0" is net.IPv4AddressString)
+    !("300.0.0.0" is net.IPv4AddressString)
+    !("1.1.1" is net.IPv4AddressString)
+    !("1.1.1." is net.IPv4AddressString)
+    !("1.1.1.1." is net.IPv4AddressString)
+    !("1.a.1.1" is net.IPv4AddressString)
+    !("1..1.1" is net.IPv4AddressString)
+    !("1..1.1.1" is net.IPv4AddressString)
+    !(".1.1.1" is net.IPv4AddressString)
+    !(".1.1.1.1" is net.IPv4AddressString)
+    !("" is net.IPv4AddressString)
+  }
+  ["IPv6AddressString (pure IPv6)"] {
+    "0:0:0:0:0:0:0:0" is net.IPv6AddressString
+    "1:2:3:4:5:6:7:8" is net.IPv6AddressString
+    "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF" is net.IPv6AddressString
+    "ffff::" is net.IPv6AddressString
+    "::" is net.IPv6AddressString
+    "::1" is net.IPv6AddressString
+    "::1:2:3:4:5:6:7" is net.IPv6AddressString
+    "1::" is net.IPv6AddressString
+    "1:2:3:4:5:6:7::" is net.IPv6AddressString
+    "::1" is net.IPv6AddressString
+    "::1:2:3:4:5:6:7" is net.IPv6AddressString
+    "1:2:3:4:5:6::7" is net.IPv6AddressString
+    "1:2:3:4:5::6:7" is net.IPv6AddressString
+    "1:2:3:4::5:6:7" is net.IPv6AddressString
+    "1:2:3::4:5:6:7" is net.IPv6AddressString
+    "1:2::3:4:5:6:7" is net.IPv6AddressString
+    "1::2:3:4:5:6:7" is net.IPv6AddressString
+    "1:2:3:4:5::6" is net.IPv6AddressString
+    "1:2:3:4::5" is net.IPv6AddressString
+    "1:2:3::4" is net.IPv6AddressString
+    "1:2::3" is net.IPv6AddressString
+    "1::2" is net.IPv6AddressString
+    !("1:2:3:4:5:6:7:8:9" is net.IPv6AddressString)
+    !("1:2:3:4:5:6:7:" is net.IPv6AddressString)
+    !("1:2:3:4:5:6:7:8:" is net.IPv6AddressString)
+    !(":1:2:3:4:5:6:7" is net.IPv6AddressString)
+    !(":1:2:3:4:5:6:7:8" is net.IPv6AddressString)
+    !("::1:2:3:4:5:6:7:8" is net.IPv6AddressString)
+    !("1:2:3:4:5:6:7:8::" is net.IPv6AddressString)
+    !("1::2::" is net.IPv6AddressString)
+    !("::1::2" is net.IPv6AddressString)
+    !("1::g" is net.IPv6AddressString)
+    !("1:::2" is net.IPv6AddressString)
+    !("FFFFF::" is net.IPv6AddressString)
+    !("1.2.3.4" is net.IPv6AddressString)
+    !("" is net.IPv6AddressString)
+  }
+  ["IPv6AddressString (IPv4-compatible)"] {
+    "::0.0.0.0" is net.IPv6AddressString
+    "::000.000.000.000" is net.IPv6AddressString
+    "::255.255.255.255" is net.IPv6AddressString
+    !("::256.0.0.0" is net.IPv6AddressString)
+    !("::260.0.0.0" is net.IPv6AddressString)
+    !("::300.0.0.0" is net.IPv6AddressString)
+    !("::0000.0.0.0" is net.IPv6AddressString)
+    !("::a.0.0.0" is net.IPv6AddressString)
+    !("::0.0.0" is net.IPv6AddressString)
+    !("::0.0.0." is net.IPv6AddressString)
+    !("::0.0.0.0." is net.IPv6AddressString)
+    !("::0.0.0.0.0" is net.IPv6AddressString)
+  }
+  ["IPv6AddressString (IPv4-mapped)"] {
+    "::ffff:0.0.0.0" is net.IPv6AddressString
+    "::ffff:000.000.000.000" is net.IPv6AddressString
+    "::ffff:255.255.255.255" is net.IPv6AddressString
+    !("::ffff:256.0.0.0" is net.IPv6AddressString)
+    !("::ffff:260.0.0.0" is net.IPv6AddressString)
+    !("::ffff:300.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0000.0.0.0" is net.IPv6AddressString)
+    !("::ffff:a.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0.0.0" is net.IPv6AddressString)
+    !("::ffff:0.0.0." is net.IPv6AddressString)
+    !("::ffff:0.0.0.0." is net.IPv6AddressString)
+    !("::ffff:0.0.0.0.0" is net.IPv6AddressString)
+  }
+  ["IPv6AddressString (IPv4-translated)"] {
+    "::ffff:0:0.0.0.0" is net.IPv6AddressString
+    "::ffff:0000:0.0.0.0" is net.IPv6AddressString
+    "::ffff:0:255.255.255.255" is net.IPv6AddressString
+    "::ffff:0:000.000.000.000" is net.IPv6AddressString
+    !("::ffff:0:256.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:260.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:300.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:0000.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:a.0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:0.0.0" is net.IPv6AddressString)
+    !("::ffff:0:0.0.0." is net.IPv6AddressString)
+    !("::ffff:0:0.0.0.0." is net.IPv6AddressString)
+    !("::ffff:0:0.0.0.0.0" is net.IPv6AddressString)
+  }
+  ["IPv6AddressString (IPv4-embedded)"] {
+    "64:ff9b::0.0.0.0" is net.IPv6AddressString
+    "0::0.0.0.0" is net.IPv6AddressString
+    "0:0:0:0::0.0.0.0" is net.IPv6AddressString
+    "ffff:ffff:ffff:ffff::255.255.255.255" is net.IPv6AddressString
+    "64:ff9b::255.255.255.255" is net.IPv6AddressString
+    "64:ff9b::000.000.000.000" is net.IPv6AddressString
+    !("64:ff9b::256.0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::260.0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::300.0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::0000.0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::a.0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::0.0.0" is net.IPv6AddressString)
+    !("64:ff9b::0.0.0." is net.IPv6AddressString)
+    !("64:ff9b::0.0.0.0." is net.IPv6AddressString)
+    !("64:ff9b::0.0.0.0.0" is net.IPv6AddressString)
+  }
+  ["IPv4CIDRString"] {
+    "0.0.0.0/1" is net.IPv4CIDRString
+    "255.255.255.255/32" is net.IPv4CIDRString
+    !("0.0.0.0/" is net.IPv4CIDRString)
+    !("0.0.0.0/100" is net.IPv4CIDRString)
+    !("0.0.0.0/a" is net.IPv4CIDRString)
+    !("/10" is net.IPv4CIDRString)
+    !("" is net.IPv4CIDRString)
+  }
+  ["IPv6CIDRString"] {
+    "fe80::/10" is net.IPv6CIDRString
+    "::1/128" is net.IPv6CIDRString
+    "::1.2.3.4/96" is net.IPv6CIDRString
+    !("fe80::/" is net.IPv6CIDRString)
+    !("fe80::/1000" is net.IPv6CIDRString)
+    !("fe80::/a" is net.IPv6CIDRString)
+    !("/10" is net.IPv6CIDRString)
+    !("" is net.IPv6CIDRString)
+    !("0.0.0.0/10" is net.IPv6CIDRString)
+  }
+  ["IPv4AddressPortString"] {
+    "0.0.0.0:0" is net.IPv4AddressPortString
+    "255.255.255.255:65535" is net.IPv4AddressPortString
+    !("0.0.0.0:" is net.IPv4AddressPortString)
+    !("0.0.0.0:123456" is net.IPv4AddressPortString)
+    !(":1" is net.IPv4AddressPortString)
+    !("" is net.IPv4AddressPortString)
+    !("0.0.0.0:a" is net.IPv4AddressPortString)
+    !("[0.0.0.0]:1" is net.IPv4AddressPortString)
+  }
+  ["IPv6AddressPortString"] {
+    "[::1]:80" is net.IPv6AddressPortString
+    "[::]:1" is net.IPv6AddressPortString
+    "[fe80::]:65535" is net.IPv6AddressPortString
+    !("[::1]:" is net.IPv6AddressPortString)
+    !("[::1]:123456" is net.IPv6AddressPortString)
+    !(":1" is net.IPv6AddressPortString)
+    !("" is net.IPv6AddressPortString)
+    !("[::1]:a" is net.IPv6AddressPortString)
+    !("0.0.0.0:1" is net.IPv6AddressPortString)
+    !("[0.0.0.0]:1" is net.IPv6AddressPortString)
+    !("::1:10" is net.IPv6AddressPortString)
+  }
 }


### PR DESCRIPTION
This PR introduces a test suite for IP address strings, complete with failing tests for IP address strings containing unicode digits, and then fixes the failing tests by changing the regexes to stop allowing unicode digits.

As part of this work I also converted the IPv6 regex into expanded form with whitespaces and comments in order to make it more readable so I could verify the test suite covered everything. The new regex is identical to the old one so no behavior changed there. That commit could be removed without changing the rest of this PR but it seems nice to have.