### PR TITLE
[org.openapis.v3] Allow using Reference as OpenApi response value

### DIFF
--- a/packages/org.openapis.v3.contrib/PklProject
+++ b/packages/org.openapis.v3.contrib/PklProject
@@ -16,7 +16,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.2"
+  version = "1.0.3"
 }
 
 dependencies {

--- a/packages/org.openapis.v3.contrib/PklProject.deps.json
+++ b/packages/org.openapis.v3.contrib/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2.1.1",
       "path": "../org.openapis.v3"
     }
   }

--- a/packages/org.openapis.v3/Operation.pkl
+++ b/packages/org.openapis.v3/Operation.pkl
@@ -82,7 +82,7 @@ requestBody: (*RequestBody|Reference)?
 /// wildcard character X. For example, 2XX represents all response codes between [200-299]. Only the following range
 /// definitions are allowed: 1XX, 2XX, 3XX, 4XX, and 5XX. If a response is defined using an explicit code, the explicit
 /// code definition takes precedence over the range definition for that code.
-responses: Mapping<HTTPResponse.Code|HTTPResponse.CodeWildcard|"default", Response>?
+responses: Mapping<HTTPResponse.Code|HTTPResponse.CodeWildcard|"default", *Response|Reference>?
 
 /// A map of possible out-of band callbacks related to the parent operation.
 ///

--- a/packages/org.openapis.v3/PklProject
+++ b/packages/org.openapis.v3/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "2.1.0"
+  version = "2.1.1"
 }


### PR DESCRIPTION
Example of usage:

```pkl
paths {
  ["/books"] {
    get {
      responses {
        [HTTPResponse.OK] = new Reference { `$ref` = "#/components/responses/200GetBooks" }
      }
    }
  }
}
```