### PR TITLE
[org.openapis.v3.contrib] Omit `required` when no fields are actually required.

### DIFF
--- a/packages/org.openapis.v3.contrib/PklProject
+++ b/packages/org.openapis.v3.contrib/PklProject
@@ -16,7 +16,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }
 
 dependencies {

--- a/packages/org.openapis.v3.contrib/SchemaGenerator.pkl
+++ b/packages/org.openapis.v3.contrib/SchemaGenerator.pkl
@@ -232,10 +232,12 @@ local function convertDeclaredType(typ: reflect.DeclaredType, seenClasses: Set<C
                   }
                 }
                 additionalProperties = false
-                required {
-                  for (_, property in _properties) {
-                    when (property.type.nullable != property.type) {
-                      property.name
+                when (_properties.any((_, property) -> property.type.nullable != property.type)) {
+                  required {
+                    for (_, property in _properties) {
+                      when (property.type.nullable != property.type) {
+                        property.name
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
Generating an empty `required` list is a spec violation.