### PR TITLE
[io.prometheus] Update Prometheus RuleGroup specs

### DIFF
--- a/packages/io.prometheus/PklProject
+++ b/packages/io.prometheus/PklProject
@@ -18,5 +18,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.1"
+  version = "1.1.2"
 }

--- a/packages/io.prometheus/Rule.pkl
+++ b/packages/io.prometheus/Rule.pkl
@@ -41,6 +41,12 @@ class RecordingRuleGroup {
   /// How often rules in the group are evaluated.
   interval: Duration?
 
+  /// Thanos Ruler's partial response behavior
+  partial_response_strategy: String?
+
+  /// Limit the number of alerts an alerting rule and series a recording rule can produce.
+  limit: Int?
+
   rules: Listing<RecordingRule>
 }
 
@@ -50,6 +56,12 @@ class AlertingRuleGroup {
 
   /// How often rules in the group are evaluated.
   interval: Duration?
+
+  /// Thanos Ruler's partial response behavior
+  partial_response_strategy: String?
+
+  /// Limit the number of alerts an alerting rule and series a recording rule can produce.
+  limit: Int?
 
   rules: Listing<AlertingRule>
 }


### PR DESCRIPTION
The current RuleGroup specs are missing some fields from Prometheus Operartor's API: https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.RuleGroup