### PR TITLE
Make conversion scripts compatible on Windows

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.6"
+  version = "1.0.7"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -15,7 +15,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.7",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.8",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {

--- a/packages/k8s.contrib.crd/generate.pkl
+++ b/packages/k8s.contrib.crd/generate.pkl
@@ -59,6 +59,7 @@ module k8s.contrib.crd.generate
 
 import "pkl:yaml"
 import "pkl:semver"
+import "pkl:platform"
 import "@deepToTyped/deepToTyped.pkl"
 import "@uri/URI.pkl"
 
@@ -87,7 +88,13 @@ source: String = read("prop:source")
 local sourceUri =
   if (source.startsWith(Regex(#"\w+:"#))) source      // absolute URI
   else if (source.startsWith("/")) "file://\(source)" // absolute file path
-  else "file://\(read("env:PWD"))/\(source)"          // relative file path
+  else                                                // relative file path
+    let (pwd = read("env:PWD"))
+    let (path =
+      if (platform.current.operatingSystem.name == "Windows") "/\(pwd)/\(source)".replaceAll("\\", "/")
+      else "\(pwd)/\(source)"
+    )
+      "file://\(URI.encode(path))"
 
 /// The CRD's source contents, as computed from [source].
 sourceContents: String|Resource = read(URI.encode(sourceUri))

--- a/packages/k8s.contrib/PklProject
+++ b/packages/k8s.contrib/PklProject
@@ -20,8 +20,9 @@ dependencies {
   ["k8s"] {
     uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1"
   }
+  ["uri"] = import("../pkl.experimental.uri/PklProject")
 }
 
 package {
-  version = "1.0.2"
+  version = "1.0.3"
 }

--- a/packages/k8s.contrib/PklProject.deps.json
+++ b/packages/k8s.contrib/PklProject.deps.json
@@ -7,6 +7,11 @@
       "checksums": {
         "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
       }
+    },
+    "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {
+      "type": "local",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
+      "path": "../pkl.experimental.uri"
     }
   }
 }

--- a/packages/k8s.contrib/convert.pkl
+++ b/packages/k8s.contrib/convert.pkl
@@ -42,10 +42,13 @@ open module k8s.contrib.convert
 
 import "pkl:reflect"
 import "pkl:yaml"
+import "pkl:platform"
+
 import "@k8s/K8sObject.pkl"
 import "@k8s/K8sResource.pkl"
 import "@k8s/api/core/v1/ResourceRequirements.pkl"
 import "@k8s/k8sSchema.pkl"
+import "@uri/URI.pkl"
 
 /// The Kubernetes resources to convert.
 ///
@@ -100,7 +103,13 @@ input = read("prop:input")
 local inputUri =
   if (input.startsWith(Regex(#"\w+:"#))) input      // absolute URI
   else if (input.startsWith("/")) "file://\(input)" // absolute file path
-  else "file://\(read("env:PWD"))/\(input)"         // relative file path
+  else                                              // relative file path
+    let (pwd = read("env:PWD"))
+      let (path =
+        if (platform.current.operatingSystem.name == "Windows") "/\(pwd)/\(input)".replaceAll("\\", "/")
+        else "\(pwd)/\(input)"
+      )
+        "file://\(URI.encode(path))"
 
 function resourceConverterFn(resource) =
   resourceConverters.fold(resource, (acc, _, f) -> f.apply(acc))

--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -25,5 +25,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.7"
+  version = "1.0.8"
 }

--- a/packages/org.json_schema.contrib/generate.pkl
+++ b/packages/org.json_schema.contrib/generate.pkl
@@ -46,6 +46,8 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module org.json_schema.contrib.generate
 
+import "pkl:platform"
+
 import "@jsonschema/Parser.pkl"
 import "@jsonschema/JsonSchema.pkl"
 import "@uri/URI.pkl"
@@ -55,7 +57,13 @@ local sourceProperty = read("prop:source")
 local sourceUri =
   if (sourceProperty.startsWith(Regex(#"\w+:"#))) sourceProperty      // absolute URI
   else if (sourceProperty.startsWith("/")) "file://\(sourceProperty)" // absolute file path
-  else "file://\(read("env:PWD"))/\(sourceProperty)"                  // relative file pat
+  else                                                // relative file path
+    let (pwd = read("env:PWD"))
+      let (path =
+        if (platform.current.operatingSystem.name == "Windows") "/\(pwd)/\(sourceProperty)".replaceAll("\\", "/")
+        else "\(pwd)/\(sourceProperty)"
+      )
+        "file://\(URI.encode(path))"
 
 local schema = read(URI.encode(sourceUri))
 

--- a/packages/pkl.pipe/PklProject
+++ b/packages/pkl.pipe/PklProject
@@ -21,7 +21,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }
 
 dependencies {

--- a/packages/pkl.pipe/PklProject.deps.json
+++ b/packages/pkl.pipe/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/k8s.contrib@1.0.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/k8s.contrib@1.0.3",
       "path": "../k8s.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
@@ -12,6 +12,11 @@
       "checksums": {
         "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
       }
+    },
+    "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {
+      "type": "local",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1.0.3",
+      "path": "../pkl.experimental.uri"
     }
   }
 }


### PR DESCRIPTION
This makes various "scripts" that read off PWD as compatible on Windows.

Also: fixes issues where a relative path may contain spaces.