### PR TITLE
[pkl.experimental.syntax] Do not generate spaces at EOL for long typealiases

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.7"
+  version = "1.0.8"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -15,12 +15,12 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.8",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.0.9",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.3",
       "path": "../pkl.experimental.syntax"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {

--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -25,5 +25,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.8"
+  version = "1.0.9"
 }

--- a/packages/org.json_schema.contrib/PklProject.deps.json
+++ b/packages/org.json_schema.contrib/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.0.3",
       "path": "../pkl.experimental.syntax"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {

--- a/packages/pkl.experimental.syntax/PklProject
+++ b/packages/pkl.experimental.syntax/PklProject
@@ -17,6 +17,6 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.2"
+  version = "1.0.3"
   apiTests = import*("tests/*.pkl").keys.toListing()
 }

--- a/packages/pkl.experimental.syntax/TypeAliasNode.pkl
+++ b/packages/pkl.experimental.syntax/TypeAliasNode.pkl
@@ -32,12 +32,21 @@ annotations: Listing<AnnotationNode>?
 
 modifiers: Listing<"external"|"local">(isDistinct)?
 
-local function renderAlias(currentIndent: String) = new Listing {
+local function renderAlias(currentIndent: String) =
+  let (typeRendered = type.render(currentIndent))
+    new Listing {
+      renderHeader(currentIndent)
+      when (!typeRendered.startsWith("\n")) { // if the type is rendered starting on the next line, do not add a space
+        " "
+      }
+      typeRendered
+    }.join("")
+
+function renderHeader(currentIndent: String) = new Listing {
   ...?modifiers
   "typealias"
   name.render(currentIndent)
   "="
-  type.render(currentIndent)
 }.join(" ")
 
 function render(currentIndent: String) = List(

--- a/packages/pkl.experimental.syntax/tests/ExpressionNode.pkl-expected.pcf
+++ b/packages/pkl.experimental.syntax/tests/ExpressionNode.pkl-expected.pcf
@@ -1,6 +1,6 @@
 examples {
   ["binary operators - basic"] {
-    "\"foo\" + \"bar\""
+    #""foo" + "bar""#
   }
   ["binary operators - precedence: no parentheses when child precedence is higher"] {
     "5 * 5 + 5 * 5"
@@ -39,10 +39,10 @@ examples {
     "super.someProperty(true)"
   }
   ["super subscript"] {
-    "super[\"test\"]"
+    #"super["test"]"#
   }
   ["subscript"] {
-    "test[\"key\"]"
+    #"test["key"]"#
     """
     (if (test)
       testTrue
@@ -51,9 +51,9 @@ examples {
     """
   }
   ["read"] {
-    "read(\"env:HOME\")"
-    "read*(\"env:HOME\")"
-    "read?(\"env:HOME\")"
+    #"read("env:HOME")"#
+    #"read*("env:HOME")"#
+    #"read?("env:HOME")"#
   }
   ["trace"] {
     "trace(test)"

--- a/packages/pkl.experimental.syntax/tests/ModuleNode.pkl
+++ b/packages/pkl.experimental.syntax/tests/ModuleNode.pkl
@@ -167,4 +167,35 @@ examples {
       }
     }.output.text
   }
+  ["typealiases"] {
+    new ModuleNode {
+      typealiases {
+        new {
+          name { value = "Short" }
+          type = new TypeNode.UnionTypeNode {
+            members {
+              new TypeNode.StringLiteralTypeNode { value = "A" }
+              new TypeNode.StringLiteralTypeNode { value = "B" }
+            }
+          }
+        }
+        new {
+          name { value = "Long" }
+          type = new TypeNode.UnionTypeNode {
+            members {
+              new TypeNode.StringLiteralTypeNode { value = "Apple" }
+              new TypeNode.StringLiteralTypeNode { value = "Blackberry" }
+              new TypeNode.StringLiteralTypeNode { value = "Cherry" }
+              new TypeNode.StringLiteralTypeNode { value = "Durian" }
+              new TypeNode.StringLiteralTypeNode { value = "Elderberry" }
+              new TypeNode.StringLiteralTypeNode { value = "Fig" }
+              new TypeNode.StringLiteralTypeNode { value = "Guava" }
+              new TypeNode.StringLiteralTypeNode { value = "Huckleberry" }
+              new TypeNode.StringLiteralTypeNode { value = "I_can't_think_of_a_fruit_that_starts_with_I" }
+            }
+          }
+        }
+      }
+    }.output.text
+  }
 }

--- a/packages/pkl.experimental.syntax/tests/ModuleNode.pkl-expected.pcf
+++ b/packages/pkl.experimental.syntax/tests/ModuleNode.pkl-expected.pcf
@@ -34,4 +34,21 @@ examples {
     
     """
   }
+  ["typealiases"] {
+    """
+    typealias Short = "A"|"B"
+    
+    typealias Long =
+      "Apple"
+      |"Blackberry"
+      |"Cherry"
+      |"Durian"
+      |"Elderberry"
+      |"Fig"
+      |"Guava"
+      |"Huckleberry"
+      |"I_can't_think_of_a_fruit_that_starts_with_I"
+    
+    """
+  }
 }


### PR DESCRIPTION
There's some extraneous diff in `packages/pkl.experimental.syntax/tests/ExpressionNode.pkl-expected.pcf` because I ran `pkl test --overwrite` and it subbed in raw strings where there were plain strings with escapes previously. I figure this is probably desirable overall, but I'd be happy to revert it based on feedback.