### PR TITLE
Bugfix: support empty Mapping in TOML output

### DIFF
--- a/packages/com.influxdata.telegraf/PklProject
+++ b/packages/com.influxdata.telegraf/PklProject
@@ -22,5 +22,5 @@ dependencies {
 }
 
 package {
-  version = "1.2.0"
+  version = "1.2.1"
 }

--- a/packages/com.influxdata.telegraf/PklProject.deps.json
+++ b/packages/com.influxdata.telegraf/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.toml@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.toml@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.toml@1.0.2",
       "path": "../pkl.toml"
     }
   }

--- a/packages/pkl.toml/PklProject
+++ b/packages/pkl.toml/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }

--- a/packages/pkl.toml/examples/basic.pkl
+++ b/packages/pkl.toml/examples/basic.pkl
@@ -38,7 +38,14 @@ database {
   }
   connection_max = 5000
   enabled = true
+  datasource_properties = new Mapping<String, String> {
+    ["driverClassName"] = "com.mysql.jdbc.Driver"
+    ["initialSize"] = "5"
+  }
+  empty_properties = new Mapping<String, String> {}
 }
+
+optional_config: Mapping<String, String>? = null
 
 servers {
   alpha {

--- a/packages/pkl.toml/tests/toml.pkl-expected.pcf
+++ b/packages/pkl.toml/tests/toml.pkl-expected.pcf
@@ -18,6 +18,12 @@ examples {
     connection_max = 5000
     enabled = true
     
+    [database.datasource_properties]
+    driverClassName = "com.mysql.jdbc.Driver"
+    initialSize = "5"
+
+    [database.empty_properties]
+
     [servers.alpha]
     ip = "10.0.0.1"
     dc = "eqdc10"

--- a/packages/pkl.toml/toml.pkl
+++ b/packages/pkl.toml/toml.pkl
@@ -194,8 +194,8 @@ class Renderer extends ValueRenderer {
     let (nativeProps = m.filter((_, value) -> !isTableTypeProp(value)))
       let (tableProps = m.filter((_, value) -> isTableTypeProp(value)))
         new Listing {
-          // If we are in an object's context, render the object header. Skip if all children are also objects.
-          when (!path.isEmpty && nativeProps.length > 0) {
+          // Only render the table header if we are in an object's context or empty map context
+          when (!path.isEmpty && (nativeProps.length > 0 || m.length == 0)) {
               """
 
               [\(makeKey(path))]


### PR DESCRIPTION
Extended the test case with an empty `Mapping` value, which did not produce a table heading in the previous version although it should.

pkl should eval an empty `Map` to an output that contains the TOML table header without further values.

The previous version explicitly skipped rendering the header assuming there were deeper tables that would follow, however that is not the case with an empty `Map`