### PR TITLE
Add an attemptApply function to deepToTyped

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.10"
+  version = "1.0.11"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.4",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.3"
+  version = "1.0.4"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -26,14 +26,14 @@ import "pkl:reflect"
 /// local dynamicBar = new Dynamic { foo { x = 1 } }
 /// apply(Bar, dynamicBar) == new Bar { foo = new Foo { x = 1 } }
 /// ```
-function apply(type: Class|TypeAlias, value: Any) =
+function apply(type: Class|TypeAlias, value: Any): Any =
   let (result =
     attemptApply(type, value)
   )
     if (result is ConversionFailure) throw(result.message) else result
 
 /// Same as [apply], but returns [ConversionFailure] rather than throwing.
-function attemptApply(type: Class|TypeAlias, value: Any) =
+function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure =
   if (type is Class)
     applyClass(reflect.Class(type), List(), value)
   else

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -28,12 +28,17 @@ import "pkl:reflect"
 /// ```
 function apply(type: Class|TypeAlias, value: Any) =
   let (result =
-    if (type is Class)
-      applyClass(reflect.Class(type), List(), value)
-    else
-      applyType(reflect.TypeAlias(type).referent, value)
+    attemptApply(type, value)
   )
     if (result is ConversionFailure) throw(result.message) else result
+
+/// Same as [apply], but returns [ConversionFailure] rather than throwing.
+function attemptApply(type: Class|TypeAlias, value: Any) =
+  if (type is Class)
+    applyClass(reflect.Class(type), List(), value)
+  else
+    applyType(reflect.TypeAlias(type).referent, value)
+
 
 local class ConversionFailure {
   message: String

--- a/packages/pkl.experimental.structuredRead/PklProject
+++ b/packages/pkl.experimental.structuredRead/PklProject
@@ -17,7 +17,7 @@ amends ".../basePklProject.pkl"
 
 
 package {
-  version = "1.0.0"
+  version = "1.0.1"
 }
 
 dependencies {

--- a/packages/pkl.experimental.structuredRead/PklProject.deps.json
+++ b/packages/pkl.experimental.structuredRead/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.4",
       "path": "../pkl.experimental.deepToTyped"
     }
   }


### PR DESCRIPTION
Sometimes you want to be able to collect multiple conversion errors from multiple deepToTyped.apply calls, this change makes that possible.