### PR TITLE
Expose the conversion failure class

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.11"
+  version = "1.0.12"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.5",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.4"
+  version = "1.0.5"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -40,7 +40,7 @@ function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure 
     applyType(reflect.TypeAlias(type).referent, value)
 
 
-local class ConversionFailure {
+class ConversionFailure {
   message: String
 
   function toMapping(): ConversionFailure = this

--- a/packages/pkl.experimental.structuredRead/PklProject
+++ b/packages/pkl.experimental.structuredRead/PklProject
@@ -17,7 +17,7 @@ amends ".../basePklProject.pkl"
 
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }
 
 dependencies {

--- a/packages/pkl.experimental.structuredRead/PklProject.deps.json
+++ b/packages/pkl.experimental.structuredRead/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.5",
       "path": "../pkl.experimental.deepToTyped"
     }
   }


### PR DESCRIPTION
The conversion failure class needs to be exposed if people are going to interpret the result of attemptApply.