### PR TITLE
Fix typo in CircleCI's `setup_remote_docker` parameter; s/docker_layer_cacheing/docker_layer_caching/

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -519,7 +519,7 @@ class SetupRemoteDockerStep extends AbstractStep {
 
   /// Set this to true to enable [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching/)
   /// in the Remote Docker Environment (default: false)
-  docker_layer_cacheing: Boolean
+  docker_layer_caching: Boolean
 }
 
 /// Special step used to persist a temporary file to be used by another job in the workflow.

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.3"
+  version = "1.1.4"
 }


### PR DESCRIPTION
According to CircleCI documentation, `docker_layer_caching` must be correct spelling of the parameter.


> docker_layer_caching | N | boolean | Set this to true to enable Docker Layer Caching in the Remote Docker Environment (default: false)
> Set this to true to enable [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching/) in the Remote Docker Environment (default: false)


https://circleci.com/docs/configuration-reference/#setupremotedocker