### PR TITLE
[com.circleci.v2] Make `setup_remote_docker` parameters as optional

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -519,7 +519,7 @@ class SetupRemoteDockerStep extends AbstractStep {
 
   /// Set this to true to enable [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching/)
   /// in the Remote Docker Environment (default: false)
-  docker_layer_caching: Boolean
+  docker_layer_caching: Boolean?
 }
 
 /// Special step used to persist a temporary file to be used by another job in the workflow.

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -511,11 +511,11 @@ class RestoreCacheStep extends AbstractStep {
 class SetupRemoteDockerStep extends AbstractStep {
   fixed hidden __name__ = "setup_remote_docker"
 
-  /// Version string of Docker you would like to use (default: 20.10.17).
+  /// Version string of Docker you would like to use (default: 24.0.9).
   ///
   /// View the list of supported docker versions
   /// [here](https://circleci.com/docs/building-docker-images/#docker-version).
-  version: String
+  version: String?
 
   /// Set this to true to enable [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching/)
   /// in the Remote Docker Environment (default: false)

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.4"
+  version = "1.1.5"
 }


### PR DESCRIPTION
According to CircleCI documentation on [setup_remote_docker](https://circleci.com/docs/configuration-reference/#setupremotedocker), both `version` and `docker_layer_caching` are NOT required one.


Key | Required | Type | Description
-- | -- | -- | --
docker_layer_caching | N | boolean | Set this to true to enable Docker Layer Caching in the Remote Docker Environment (default: false)
version | N | String | Version string of Docker you would like to use (default: 24.0.9). View the list of supported Docker versions here.

cf. https://circleci.com/docs/configuration-reference/#setupremotedocker