### PR TITLE
[com.circleci.v2] Support job-level parameters

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -152,6 +152,9 @@ class Job {
   /// Number of parallel instances of this job to run (default: 1)
   parallelism: Int?
 
+  /// Job-level parameters can be used when calling a job in a workflow
+  parameters: Mapping<String, Parameter>?
+
   /// A map of environment variable names and values.
   environment: Mapping<String, String>?
 

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.6"
+  version = "1.2.0"
 }

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.5"
+  version = "1.1.6"
 }


### PR DESCRIPTION
Just as similar as pipeline parameters (toplevel), CircleCI also supports `parameters` at job-level (cf. https://circleci.com/docs/configuration-reference/#parameters-job). The parameter syntax is [identical to the pipeline parameters](https://circleci.com/docs/reusing-config/#parameter-syntax).

Job-level parameters are useful especially when I'm configuring [matrix builds](https://circleci.com/docs/configuration-reference/#matrix). I'd like this to be supported :pray: