### PR TITLE
Parameter passing from workflow job

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -366,6 +366,11 @@ class WorkflowJob {
 
   /// Job Filters can have the key branches or tags
   filters: JobFilters?
+
+  /// A job may have input parameters in their defintion.
+  ///
+  /// A mapping of the parameter name and value must be passed when instatiation the job.
+  parameters: Mapping<String, String|Boolean|Number>?
 }
 
 class JobFilters {
@@ -782,6 +787,13 @@ output {
   renderer = new YamlRenderer {
     converters {
       [AbstractStep] = (it) -> Map(it.__name__, it.toMap())
+      [WorkflowJob] = (it) ->
+        if (it.parameters != null)
+          new Dynamic {
+            ...it.toMap().remove("parameters")
+            ...it.parameters.toMap()
+          }
+        else it
       [Dynamic] = (it) ->
         if (it.hasProperty("__name__"))
           Map(it.__name__, it.toMap().remove("__name__"))

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.2.0"
+  version = "1.2.1"
 }

--- a/packages/com.circleci.v2/examples/job_with_params.pkl
+++ b/packages/com.circleci.v2/examples/job_with_params.pkl
@@ -108,7 +108,7 @@ local apply = "apply"
 local contextValue = "infra_context"
 local bucket = "infra_s3_bucket"
 local workspaceAProjectDir = "./infra/workspace-a"
-local workspaceBProjectDir = "./infra/workspace-a"
+local workspaceBProjectDir = "./infra/workspace-b"
 
 local function getWorkflowJobName(jobName: String): String = "wf-job-" + jobName
 

--- a/packages/com.circleci.v2/examples/job_with_params.pkl
+++ b/packages/com.circleci.v2/examples/job_with_params.pkl
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// This example uses steps from the [circleci/node](https://circleci.com/developer/orbs/orb/circleci/node) orb.
+///
+/// It defins local classes that extend [AbstractStep], so that step definitions are type safe.
+amends "../Config.pkl"
+
+local tofuExecutor = "tofu-executor"
+local executorImage = "ghcr.io/opentofu/opentofu:latest"
+local executorResourceClass = "small"
+
+executors = new {
+  [tofuExecutor] = new Executor {
+    docker {
+      new DockerImage { image = executorImage }
+    }
+    resource_class = executorResourceClass
+  }
+}
+
+jobs {
+  [init] = new Job {
+    parameters {
+      ["project_dir"] = new Parameter { type = "string" }
+      ["bucket"] = new Parameter { type = "string" }
+      ["key"] = new Parameter { type = "string" }
+    }
+    steps {
+      "checkout"
+      new RunStep {
+        name = "OpenTofu Init and Validate"
+        command = """
+            cd << parameters.project_dir >>
+            tofu init \\
+              -backend-config="bucket=<< parameters.bucket >>" \\
+              -backend-config="key=<< parameters.key >>"
+            tofu validate
+          """
+      }
+      new PersistToWorkspaceStep {
+        root = "."
+        paths = new Listing {
+          "<< parameters.project_dir >>/.terraform"
+          "<< parameters.project_dir >>/.terraform.lock.hcl"
+        }
+      }
+    }
+    executor = tofuExecutor
+  }
+
+  [plan] = new Job {
+    parameters {
+      ["project_dir"] = new Parameter { type = "string" }
+    }
+    steps {
+      "checkout"
+      new AttachWorkspaceStep {
+        at = "."
+      }
+      new RunStep {
+        name = "OpenTofu Plan"
+        command = """
+            cd << parameters.project_dir >>
+            tofu plan
+          """
+      }
+    }
+    executor = tofuExecutor
+  }
+
+  [apply] = new Job {
+    parameters {
+      ["project_dir"] = new Parameter { type = "string" }
+    }
+    steps {
+      "checkout"
+      new AttachWorkspaceStep {
+        at = "."
+      }
+      new RunStep {
+        name = "OpenTofu Apply"
+        command = """
+            cd << parameters.project_dir >>
+            tofu apply -auto-approve tfplan
+          """
+      }
+    }
+    executor = tofuExecutor
+  }
+}
+
+local init = "init-validate"
+local plan = "plan"
+local apply = "apply"
+local contextValue = "infra_context"
+local bucket = "infra_s3_bucket"
+local workspaceAProjectDir = "./infra/workspace-a"
+local workspaceBProjectDir = "./infra/workspace-a"
+
+local function getWorkflowJobName(jobName: String): String = "wf-job-" + jobName
+
+workflows {
+  ["wf-tf-workspace-a"] {
+    jobs = new Listing {
+      new Mapping {
+        [init] = new WorkflowJob {
+          name = getWorkflowJobName(init)
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceAProjectDir
+            ["bucket"] = bucket
+            ["key"] = "workspace-a/terraform.tfstate"
+          }
+        }
+      }
+      new Mapping {
+        [plan] = new WorkflowJob {
+          name = getWorkflowJobName(plan)
+          requires = new Listing { getWorkflowJobName(init) }
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceAProjectDir
+          }
+        }
+      }
+      new Mapping {
+        [apply] = new WorkflowJob {
+          name = getWorkflowJobName(apply)
+          type = "approval"
+          requires = new Listing {getWorkflowJobName(plan)}
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceAProjectDir
+          }
+        }
+      }
+    }
+  }
+  ["wf-tf-workspace-b"] {
+    jobs = new Listing {
+      new Mapping {
+        [init] = new WorkflowJob {
+          name = getWorkflowJobName(init)
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceBProjectDir
+            ["bucket"] = bucket
+            ["key"] = "workspace-b/terraform.tfstate"
+          }
+        }
+      }
+      new Mapping {
+        [plan] = new WorkflowJob {
+          name = getWorkflowJobName(plan)
+          requires = new Listing { getWorkflowJobName(init) }
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceBProjectDir
+          }
+        }
+      }
+      new Mapping {
+        [apply] = new WorkflowJob {
+          name = getWorkflowJobName(apply)
+          type = "approval"
+          requires = new Listing {getWorkflowJobName(plan)}
+          context = contextValue
+          parameters = new Mapping {
+            ["project_dir"] = workspaceBProjectDir
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
+++ b/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
@@ -239,7 +239,7 @@ examples {
         - init-validate:
             name: wf-job-init-validate
             context: infra_context
-            project_dir: ./infra/workspace-a
+            project_dir: ./infra/workspace-b
             bucket: infra_s3_bucket
             key: workspace-b/terraform.tfstate
         - plan:
@@ -247,14 +247,14 @@ examples {
             requires:
             - wf-job-init-validate
             context: infra_context
-            project_dir: ./infra/workspace-a
+            project_dir: ./infra/workspace-b
         - apply:
             name: wf-job-apply
             requires:
             - wf-job-plan
             context: infra_context
             type: approval
-            project_dir: ./infra/workspace-a
+            project_dir: ./infra/workspace-b
     
     """#
   }

--- a/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
+++ b/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
@@ -150,6 +150,114 @@ examples {
     
     """
   }
+  ["job_with_params.yaml"] {
+    #"""
+    # Generated from CircleCI.pkl. DO NOT EDIT.
+    version: '2.1'
+    executors:
+      tofu-executor:
+        resource_class: small
+        docker:
+        - image: ghcr.io/opentofu/opentofu:latest
+    jobs:
+      init-validate:
+        steps:
+        - checkout
+        - run:
+            command: |2-
+                cd << parameters.project_dir >>
+                tofu init \
+                  -backend-config="bucket=<< parameters.bucket >>" \
+                  -backend-config="key=<< parameters.key >>"
+                tofu validate
+            name: OpenTofu Init and Validate
+        - persist_to_workspace:
+            root: '.'
+            paths:
+            - << parameters.project_dir >>/.terraform
+            - << parameters.project_dir >>/.terraform.lock.hcl
+        executor: tofu-executor
+        parameters:
+          project_dir:
+            type: string
+          bucket:
+            type: string
+          key:
+            type: string
+      plan:
+        steps:
+        - checkout
+        - attach_workspace:
+            at: '.'
+        - run:
+            command: |2-
+                cd << parameters.project_dir >>
+                tofu plan
+            name: OpenTofu Plan
+        executor: tofu-executor
+        parameters:
+          project_dir:
+            type: string
+      apply:
+        steps:
+        - checkout
+        - attach_workspace:
+            at: '.'
+        - run:
+            command: |2-
+                cd << parameters.project_dir >>
+                tofu apply -auto-approve tfplan
+            name: OpenTofu Apply
+        executor: tofu-executor
+        parameters:
+          project_dir:
+            type: string
+    workflows:
+      wf-tf-workspace-a:
+        jobs:
+        - init-validate:
+            name: wf-job-init-validate
+            context: infra_context
+            project_dir: ./infra/workspace-a
+            bucket: infra_s3_bucket
+            key: workspace-a/terraform.tfstate
+        - plan:
+            name: wf-job-plan
+            requires:
+            - wf-job-init-validate
+            context: infra_context
+            project_dir: ./infra/workspace-a
+        - apply:
+            name: wf-job-apply
+            requires:
+            - wf-job-plan
+            context: infra_context
+            type: approval
+            project_dir: ./infra/workspace-a
+      wf-tf-workspace-b:
+        jobs:
+        - init-validate:
+            name: wf-job-init-validate
+            context: infra_context
+            project_dir: ./infra/workspace-a
+            bucket: infra_s3_bucket
+            key: workspace-b/terraform.tfstate
+        - plan:
+            name: wf-job-plan
+            requires:
+            - wf-job-init-validate
+            context: infra_context
+            project_dir: ./infra/workspace-a
+        - apply:
+            name: wf-job-apply
+            requires:
+            - wf-job-plan
+            context: infra_context
+            type: approval
+            project_dir: ./infra/workspace-a
+    
+    """#
+  }
   ["typed_orb_steps.yaml"] {
     """
     # Generated from CircleCI.pkl. DO NOT EDIT.


### PR DESCRIPTION
Allow passing parameters from a workflow job to a job definition as can be seen in circleci documentation [here](https://circleci.com/docs/pipeline-variables/#element-parameter-scope). I'm attempting to use it for generating pipelines to different terraform workspaces dynamically as seen in the text example included.

I wasn't sure what was the more idiomatic way to make these parameters be embedded at the same level as the rest of the params in `WorkflowJob`, so I just added a case on the `YamlRenderer.converters` field. 

In my own code I have a validation to guarantee the fields inside are not repeated with the following code:
```pkl
  parameters: Mapping<String, String|Boolean|Number>?

  // Use reflection to get property names
  hidden reservedFields: Set<String> =
    reflect.Class(CustomWorkflowJob).properties
      .filter((name, _) -> name != "parameters" && name != "reservedFields" && name != "validateExtraFields")
      .mapValues((_, prop) -> prop.name)
      .values
      .toSet()

  hidden validateParameters = !parameters.keys.any((key) -> reservedFields.contains(key)) || throw("Extra fields cannot use reserved names: \(reservedFields)")
```

I didn't add this validation to avoid importing the `reflect` package.