### PR TITLE
[com.circleci.v2] Support specifying custom job-level parameters while calling a job in a workflow

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -367,12 +367,16 @@ class WorkflowJob {
   /// Job Filters can have the key branches or tags
   filters: JobFilters?
 
-  /// Supplemental job-level parameters to be specified while calling a job in workflow.
+  /// Supplemental job-level parameters to be specified when
+  /// [calling a `job` in `workflow`](https://circleci.com/docs/configuration-reference/#jobs-in-workflow).
+  ///
   /// There are several reserved parameter names that cannot be used from CircleCI users.
-  /// https://circleci.com/docs/configuration-reference/#parameters-job
-  hidden parameters: Mapping<String(
-      !matches(Regex("^(name|context|filters|matrix|requires|type)$"))
-    ), (String|Number|Boolean)>?
+  ///
+  /// For more information, see <https://circleci.com/docs/configuration-reference/#parameters-job>.
+  hidden parameters: Mapping<
+    String(!(this is "name"|"context"|"filters"|"matrix"|"requires"|"type")),
+    *Listing<Step>|String|Number|Boolean
+  >?
 }
 
 class JobFilters {

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -371,8 +371,6 @@ class WorkflowJob {
   /// [calling a `job` in `workflow`](https://circleci.com/docs/configuration-reference/#jobs-in-workflow).
   ///
   /// There are several reserved parameter names that cannot be used from CircleCI users.
-  ///
-  /// For more information, see <https://circleci.com/docs/configuration-reference/#parameters-job>.
   hidden parameters: Mapping<
     String(!(this is "name"|"context"|"filters"|"matrix"|"requires"|"type")),
     *Listing<Step>|String|Number|Boolean

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -366,6 +366,13 @@ class WorkflowJob {
 
   /// Job Filters can have the key branches or tags
   filters: JobFilters?
+
+  /// Supplemental job-level parameters to be specified while calling a job in workflow.
+  /// There are several reserved parameter names that cannot be used from CircleCI users.
+  /// https://circleci.com/docs/configuration-reference/#parameters-job
+  hidden parameters: Mapping<String(
+      !matches(Regex("^(name|context|filters|matrix|requires|type)$"))
+    ), (String|Number|Boolean)>?
 }
 
 class JobFilters {
@@ -786,6 +793,8 @@ output {
         if (it.hasProperty("__name__"))
           Map(it.__name__, it.toMap().remove("__name__"))
         else it
+      [WorkflowJob] = (it) ->
+        it.toMap() + (it.parameters ?? Map()).toMap()
     }
   }
 }

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.2.0"
+  version = "1.3.0"
 }

--- a/packages/com.circleci.v2/examples/build_and_push_image_w_registry_login.pkl
+++ b/packages/com.circleci.v2/examples/build_and_push_image_w_registry_login.pkl
@@ -1,0 +1,37 @@
+amends ".../Config.pkl"
+
+version = "2.1"
+
+orbs {
+  ["aws-ecr"] = "circleci/aws-ecr@9.0"
+  ["aws-cli"] = "circleci/aws-cli@5.1"
+}
+
+workflows {
+  ["build-and-push-image-with-container-registry-login"] {
+    jobs {
+      new {
+        ["aws-ecr/build_and_push_image"] {
+          parameters {
+            ["container_registry_login"] = true
+            ["registry_login"] {
+              module.run("docker login -u ${HEROKU_USERNAME} -p ${HEROKU_API_KEY}")
+              module.run("docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}")
+              module.run("docker login -u ${DOCKERHUB_ID} -p ${DOCKERHUB_PASSWORD}")
+            }
+            ["auth"] {
+              (module.OrbStep("aws-cli/setup")) {
+                role_arn = "arn:aws:iam::123456789012"
+              }
+            }
+            ["repo"] = "my-sample-repo"
+            ["tag"] = "sampleTag"
+            ["dockerfile"] = "Dockerfile"
+            ["path"] = "."
+            ["region"] = "us-west-2"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/com.circleci.v2/examples/build_and_push_image_w_registry_login.pkl
+++ b/packages/com.circleci.v2/examples/build_and_push_image_w_registry_login.pkl
@@ -1,4 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
 amends ".../Config.pkl"
+// Adaptation of https://github.com/CircleCI-Public/aws-ecr-orb/blob/v9.3.7/src/examples/build_and_push_image_w_registry_login.yml#L21-L36
 
 version = "2.1"
 

--- a/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
+++ b/packages/com.circleci.v2/tests/Config.pkl-expected.pcf
@@ -1,4 +1,34 @@
 examples {
+  ["build_and_push_image_w_registry_login.yaml"] {
+    """
+    # Generated from CircleCI.pkl. DO NOT EDIT.
+    version: '2.1'
+    orbs:
+      aws-ecr: circleci/aws-ecr@9.0
+      aws-cli: circleci/aws-cli@5.1
+    workflows:
+      build-and-push-image-with-container-registry-login:
+        jobs:
+        - aws-ecr/build_and_push_image:
+            container_registry_login: true
+            registry_login:
+            - run:
+                command: docker login -u ${HEROKU_USERNAME} -p ${HEROKU_API_KEY}
+            - run:
+                command: docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
+            - run:
+                command: docker login -u ${DOCKERHUB_ID} -p ${DOCKERHUB_PASSWORD}
+            auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::123456789012
+            repo: my-sample-repo
+            tag: sampleTag
+            dockerfile: Dockerfile
+            path: '.'
+            region: us-west-2
+    
+    """
+  }
   ["concurrent_workflow.yaml"] {
     """
     # Generated from CircleCI.pkl. DO NOT EDIT.


### PR DESCRIPTION
By default CircleCI workflow jobs can take parameters like `name`, `context`, `type`, `filters`, etc. Along with these default parameters, it is not very explicitly described on [CircleCI's configuration reference](https://circleci.com/docs/configuration-reference/#job-name-in-workflow), however, it also can take custom job-level parameters defined by users.

So far there was no way to specify these custom parameters while calling a workflow job. This allows user to specify custom `parameters` while invoking a WorkflowJob.


---
Here's some references of usage of job-level custom parameters. JFYI

https://github.com/CircleCI-Public/aws-ecr-orb/blob/v9.3.7/src/examples/build_and_push_image_w_registry_login.yml#L21-L36
https://github.com/CircleCI-Public/aws-ecr-orb/blob/v9.3.7/src/jobs/build_and_push_image.yml#L8-L214