### PR TITLE
[com.circleci.v2] Support CircleCI workflow job matrix

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -364,6 +364,11 @@ class WorkflowJob {
   /// For more information see the Using Workflows to Orchestrate Jobs page.
   type: "approval"?
 
+  /// Run a parameterized job multiple times with different arguments.
+  ///
+  /// For more information see the how-to guide on [Using Matrix Jobs](https://circleci.com/docs/using-matrix-jobs/).
+  ///
+  /// In order to use the matrix stanza, you must use parameterized jobs.
   matrix: JobMatrix?
 
   /// Job Filters can have the key branches or tags
@@ -408,8 +413,15 @@ class FilterSpec {
 }
 
 class JobMatrix {
-  parameters: Mapping<String, Listing<(String|Number|Boolean)>>
+  /// A map of parameter names to every value the job should be called with
+  parameters: Mapping<String, Listing<String|Number|Boolean>>
+
+  /// Argument maps that should be excluded from the matrix
   exclude: Listing<Mapping<String, String>>?
+
+  /// An alias for the matrix, usable from another job’s requires stanza.
+  ///
+  /// Defaults to the name of the job being executed
   alias: String?
 }
 

--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -364,6 +364,8 @@ class WorkflowJob {
   /// For more information see the Using Workflows to Orchestrate Jobs page.
   type: "approval"?
 
+  matrix: JobMatrix?
+
   /// Job Filters can have the key branches or tags
   filters: JobFilters?
 }
@@ -403,6 +405,12 @@ class FilterSpec {
 
   /// Either a single branch specifier, or a list of branch specifiers
   ignore: (String|Listing<String>)?
+}
+
+class JobMatrix {
+  parameters: Mapping<String, Listing<(String|Number|Boolean)>>
+  exclude: Listing<Mapping<String, String>>?
+  alias: String?
 }
 
 typealias Step = AbstractStep|SimpleStepName|OrbStep

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.2.0"
+  version = "1.4.0"
 }


### PR DESCRIPTION
Adds support for CircleCI's matrix jobs.

The configuration schema was simple enough to implement it in Pkl as it is.

Key | Required | Type | Description
-- | -- | -- | --
parameters | Y | Map | A map of parameter names to every value the job should be called with
exclude | N | List | A list of argument maps that should be excluded from the matrix
alias | N | String | An alias for the matrix, usable from another job’s requires stanza. Defaults to the name of the job being executed


https://circleci.com/docs/configuration-reference/#matrix