### PR TITLE
[pkl.experimental.deepToTyped] Add support for key transformations during apply

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.13"
+  version = "1.0.14"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.5",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.0",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.5"
+  version = "1.1.0"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -126,10 +126,13 @@ local function getAllProperties(clazz: reflect.Class?): Map<String, reflect.Prop
   else if (doesNotInherit(clazz)) clazz.properties
   else getAllProperties(clazz.superclass!!) + clazz.properties
 
+hidden keyTransform: Function1<reflect.Property, String>?
+
 local function applyProperty(valueAsMap: Map, prop: reflect.Property) =
-  if (valueAsMap.containsKey(prop.name)) applyType(prop.type, valueAsMap[prop.name])
-  else if (!(prop.type is reflect.NullableType) && prop.defaultValue != null) prop.defaultValue
-  else null
+  let (propName = keyTransform?.ifNonNull((it) -> (it as Function1<reflect.Property, String>).apply(prop)) ?? prop.name)
+    if (valueAsMap.containsKey(propName)) applyType(prop.type, valueAsMap[propName])
+    else if (!(prop.type is reflect.NullableType) && prop.defaultValue != null) prop.defaultValue
+    else null
 
 local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping): Typed|ConversionFailure =
   let (valueAsMap = value.toMap())

--- a/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
@@ -147,6 +147,21 @@ local class LooselyTyped {
   anything: Any
 }
 
+local class KeyTransform extends Annotation {
+  name: String
+}
+
+local class ClassWithKeyTranform {
+  @KeyTransform { name = "my_field" }
+  myField: String
+  inner: InnerClassWithKeyTranform
+}
+
+local class InnerClassWithKeyTranform {
+  @KeyTransform { name = "my_nested_field" }
+  myNestedField: String
+}
+
 facts {
   ["Basic types"] {
     t.apply(Int, 1) == 1
@@ -317,5 +332,25 @@ facts {
       anything = "anything"
     }
     t.apply(LooselyTyped, looselyTypedString) == looselyTypedStringExpected
+  }
+
+  ["Supports key transformations, eg. via annotation"] {
+    local input = new Dynamic {
+      my_field = "hello"
+      inner {
+        my_nested_field = "world"
+      }
+    }
+
+    local expectedClassWithKeyTranform = new ClassWithKeyTranform {
+      myField = "hello"
+      inner {
+        myNestedField = "world"
+      }
+    }
+
+    new t {
+      keyTransform = (prop) -> prop.annotations.findOrNull((it) -> it is KeyTransform)?.name
+    }.apply(ClassWithKeyTranform, input) == expectedClassWithKeyTranform
   }
 }

--- a/packages/pkl.experimental.structuredRead/PklProject
+++ b/packages/pkl.experimental.structuredRead/PklProject
@@ -17,7 +17,7 @@ amends ".../basePklProject.pkl"
 
 
 package {
-  version = "1.0.2"
+  version = "1.0.3"
 }
 
 dependencies {

--- a/packages/pkl.experimental.structuredRead/PklProject.deps.json
+++ b/packages/pkl.experimental.structuredRead/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.0.5",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.0",
       "path": "../pkl.experimental.deepToTyped"
     }
   }


### PR DESCRIPTION
Sometimes a complex, nested Pkl class/module must be "unmarshalled" from a serialized format like JSON or YAML. `pkl.experimental.deepToTyped` is the low-boilerplate tool of choice for such transformations. Occasionally, the names of properties in the input data do not match the property names of Pkl types, for example Pkl typically uses `camelCase` while JSON can use `snake_case` or `kebab-case`. `deepToTyped` cannot currently handle this task.

This PR introduces a new customization point in the `deepToTyped` module: the `keyTransform` property can be set to a function mapping a `reflect.Property` to the `String` name that should be used to find the property's value in the input instead of its name. If this function returns `null`, the property's original name is used.