### PR TITLE
[org.openapis.v3] Security Scheme Update for HTTP/Bearer Auth

### DIFF
--- a/packages/org.openapis.v3.contrib/PklProject
+++ b/packages/org.openapis.v3.contrib/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.4"
+  version = "1.0.5"
 }
 
 dependencies {

--- a/packages/org.openapis.v3.contrib/PklProject.deps.json
+++ b/packages/org.openapis.v3.contrib/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2.1.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.openapis.v3@2.1.3",
       "path": "../org.openapis.v3"
     }
   }

--- a/packages/org.openapis.v3/PklProject
+++ b/packages/org.openapis.v3/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/org.openapis.v3/PklProject
+++ b/packages/org.openapis.v3/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "2.1.2"
+  version = "2.1.3"
 }

--- a/packages/org.openapis.v3/SecurityScheme.pkl
+++ b/packages/org.openapis.v3/SecurityScheme.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/org.openapis.v3/SecurityScheme.pkl
+++ b/packages/org.openapis.v3/SecurityScheme.pkl
@@ -19,6 +19,7 @@ module org.openapis.v3.SecurityScheme
 import "OAuthFlows.pkl"
 
 typealias SecuritySchemeType = "apiKey"|"http"|"oauth2"|"openIdConnect"
+typealias SecuritySchemeIn = "query"|"header"|"cookie"
 
 /// The type of the security scheme.
 type: SecuritySchemeType
@@ -30,10 +31,10 @@ type: SecuritySchemeType
 description: String?
 
 /// The name of the header, query or cookie parameter to be used.
-name: String
+name: String?((type == "apiKey").implies(this != null))
 
 /// The location of the API key.
-`in`: "query"|"header"|"cookie"
+`in`: SecuritySchemeIn?((type == "apiKey").implies(this != null))
 
 scheme: String((this == "bearer").implies(bearerFormat != null))
 

--- a/packages/org.openapis.v3/SecurityScheme.pkl
+++ b/packages/org.openapis.v3/SecurityScheme.pkl
@@ -31,7 +31,7 @@ type: SecuritySchemeType
 description: String?
 
 /// The name of the header, query or cookie parameter to be used.
-name: String?((type == "apiKey").implies(this != null))
+name: String?((this != null).implies(type == "apiKey"))
 
 /// The location of the API key.
 `in`: SecuritySchemeIn?((type == "apiKey").implies(this != null))

--- a/packages/org.openapis.v3/SecurityScheme.pkl
+++ b/packages/org.openapis.v3/SecurityScheme.pkl
@@ -34,7 +34,7 @@ description: String?
 name: String?((this != null).implies(type == "apiKey"))
 
 /// The location of the API key.
-`in`: SecuritySchemeIn?((type == "apiKey").implies(this != null))
+`in`: SecuritySchemeIn?((this != null).implies(type == "apiKey"))
 
 scheme: String((this == "bearer").implies(bearerFormat != null))
 


### PR DESCRIPTION
This pull request addresses the issue of being able to make a correctly configured security scheme for HTTP security schemes like Bearer Auth Tokens.

For more information, see the original issue: #90