### PR TITLE
Fix name conflicts in k8s CRD and JSON schema generators

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "2.0.0"
+  version = "2.0.1"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -15,7 +15,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.1.2",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.1.3",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {

--- a/packages/k8s.contrib.crd/internal/ModuleGenerator.pkl
+++ b/packages/k8s.contrib.crd/internal/ModuleGenerator.pkl
@@ -277,6 +277,31 @@ local function generatePklClass(schema: JsonSchema, className: Type, typeNames: 
 function isClassLike(schema: JsonSchema.Schema): Boolean =
   !(schema is Boolean) && schema.properties != null
 
+// only need to include stdlib names that would be used by the code generator
+const local builtInNames = Set(
+  "Mapping",
+  "Listing",
+  "Dynamic",
+  "String",
+  "Boolean",
+  "Int",
+  "Int16",
+  "Int32",
+  "UInt",
+  "UInt8",
+  "UInt16",
+  "UInt32",
+  "Float",
+  "Null",
+  "Number",
+  "Deprecated"
+)
+
+local function normalizeTypeName(name: String) =
+  let (capitalized = utils.pascalCase(name))
+    if (builtInNames.contains(capitalized)) "\(capitalized)1"
+    else capitalized
+
 /// Determines the name of a type.
 ///
 /// Try to use the parent property's name as part of the class name in case of conflict.
@@ -287,7 +312,7 @@ local function determineTypeName(
   existingTypeNames: Set<Type>,
   index: Int
 ): Type =
-  let (candidate = utils.pascalCase(candidateName))
+  let (candidate = normalizeTypeName(candidateName))
     if (existingTypeNames.findOrNull((it) -> it.name == candidate) != null)
       if (path.isEmpty)
         determineTypeName(

--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -25,5 +25,5 @@ dependencies {
 }
 
 package {
-  version = "1.1.2"
+  version = "1.1.3"
 }

--- a/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
+++ b/packages/org.json_schema.contrib/internal/ModuleGenerator.pkl
@@ -206,12 +206,37 @@ function isClassLike(schema: JsonSchema.Schema): Boolean =
     // Edge case: if `$ref` exists, any other property should be ignored.
     schema.$ref == null && schema.properties != null
 
+// only need to include stdlib names that would be used by the code generator
+const local builtInNames = Set(
+  "Mapping",
+  "Listing",
+  "Dynamic",
+  "String",
+  "Boolean",
+  "Int",
+  "Int16",
+  "Int32",
+  "UInt",
+  "UInt8",
+  "UInt16",
+  "UInt32",
+  "Float",
+  "Null",
+  "Number",
+  "Deprecated"
+)
+
+local function normalizeTypeName(name: String) =
+  let (capitalized = utils.pascalCase(name))
+    if (builtInNames.contains(capitalized)) "\(capitalized)1"
+    else capitalized
+
 /// Determine the name of a type.
 ///
 /// Try to use the parent property's name as part of the class name in case of conflict.
 /// If already at the root, add a number at the end.
 local function determineTypeName(path: List<String>, candidateName: String, existingTypeNames: Set<Type>, index: Int): Type =
-  let (candidateType = new Type { name = utils.pascalCase(candidateName); moduleName = module.moduleName })
+  let (candidateType = new Type { name = normalizeTypeName(candidateName); moduleName = module.moduleName })
     if (existingTypeNames.contains(candidateType))
       if (path.isEmpty)
         determineTypeName(path, candidateName + index.toString(), existingTypeNames, index + 1)
@@ -219,7 +244,7 @@ local function determineTypeName(path: List<String>, candidateName: String, exis
         let (newPath = dropLast(path))
           determineTypeName(
             newPath,
-            getCandidateName(newPath) + utils.pascalCase(candidateName),
+            getCandidateName(newPath) + normalizeTypeName(candidateName),
             existingTypeNames,
             index
           )

--- a/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl
+++ b/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl
@@ -375,4 +375,67 @@ examples {
     local schema = Parser.parse(read("fixtures/test_conflicts.json")) as JsonSchema
     new ModuleGenerator { rootSchema = schema; moduleName = "com.Example" }.moduleNode.render("")
   }
+  ["name conflicts with built-in class name"] {
+    local schema: JsonSchema = new {
+      type = "object"
+      additionalProperties = false
+      properties {
+        ["int"] {
+          type = "object"
+          properties {
+            ["res1"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+        ["boolean"] {
+          type = "object"
+          properties {
+            ["res2"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+        ["mapping"] {
+          type = "object"
+          properties {
+            ["res3"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+        ["listing"] {
+          type = "object"
+          properties {
+            ["res4"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+        ["dynamic"] {
+          type = "object"
+          properties {
+            ["res5"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+        ["null"] {
+          type = "object"
+          properties {
+            ["res6"] {
+              type = "string"
+            }
+          }
+          additionalProperties = false
+        }
+      }
+    }
+    new ModuleGenerator { rootSchema = schema; moduleName = "com.Example" }.moduleNode.output.text
+  }
 }

--- a/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/org.json_schema.contrib/tests/ModuleGenerator.pkl-expected.pcf
@@ -541,4 +541,47 @@ examples {
     
     """
   }
+  ["name conflicts with built-in class name"] {
+    """
+    /// This module was generated from JSON Schema from <>.
+    module com.Example
+    
+    int: Int1?
+    
+    boolean: Boolean1?
+    
+    mapping: Mapping1?
+    
+    listing: Listing1?
+    
+    dynamic: Dynamic1?
+    
+    `null`: Null1?
+    
+    class Int1 {
+      res1: String?
+    }
+    
+    class Boolean1 {
+      res2: String?
+    }
+    
+    class Mapping1 {
+      res3: String?
+    }
+    
+    class Listing1 {
+      res4: String?
+    }
+    
+    class Dynamic1 {
+      res5: String?
+    }
+    
+    class Null1 {
+      res6: String?
+    }
+    
+    """
+  }
 }


### PR DESCRIPTION
For example, handles if a class name would otherwise be generated as `Mapping`.
This instead turns it into `Mapping1`.