### PR TITLE
Add support for `m2pro` (medium, large) resource classes

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -202,6 +202,8 @@ typealias ResourceClass =
   |"arm.2xlarge"
   |"macos.m1.medium.gen1"
   |"macos.m1.large.gen1"
+  |"m2pro.medium"
+  |"m2pro.large"
   |"windows.medium"
   |"windows.large"
   |"windows.xlarge"

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.4.0"
+  version = "1.5.0"
 }


### PR DESCRIPTION
Bumped version to 1.5.0.

## Resource information

![Screenshot 2025-03-07 at 17 07 27](https://github.com/user-attachments/assets/7d70caf5-8180-4f82-b215-cbd374e5dacf)

See: https://circleci.com/docs/configuration-reference/#macos-execution-environment