### PR TITLE
[k8s.contrib.crd] Generate CRDs for every version

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -25,9 +25,9 @@ dependencies {
   ["uri"] = import("../pkl.experimental.uri/PklProject")
   ["syntax"] = import("../pkl.experimental.syntax/PklProject")
 
-  ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1" }
+  ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.2.0" }
 }
 
 package {
-  version = "2.0.2"
+  version = "3.0.0"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -3,9 +3,9 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.2.0",
       "checksums": {
-        "sha256": "75c6d66d94c335417a3c502e107aaeadf7a60b4e1d34b2c979afe11193205a1a"
+        "sha256": "5a37ac359c21442ddba07e339fa211b0db8999104715e891e7d2dab0228ace47"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {

--- a/packages/k8s.contrib.crd/generate.pkl
+++ b/packages/k8s.contrib.crd/generate.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,12 +133,15 @@ converters: Mapping<String, Mapping<List<String>, Module|Class|TypeAlias>>?
 
 fixed modules: Listing<ModuleGenerator> = new {
   for (_crd in crds) {
-    new ModuleGenerator {
-      k8sImportPath = module.k8sImportPath
-      crd = _crd
-      baseUri = URI.parse(sourceUri)!!
-      converters = module.converters?.getOrNull(crd.metadata.name) ?? new Mapping {}
-      logPaths = module.logPaths ?? false
+    for (_version in _crd.spec.versions) {
+      new ModuleGenerator {
+        k8sImportPath = module.k8sImportPath
+        crd = _crd
+        version = _version
+        baseUri = URI.parse(sourceUri)!!
+        converters = module.converters?.getOrNull(crd.metadata.name) ?? new Mapping {}
+        logPaths = module.logPaths ?? false
+      }
     }
   }
 }
@@ -147,7 +150,7 @@ output {
   text = throw("The JSON Schema generator only works with multiple-file output. Try running again with the -m option.")
   files {
     for (mod in modules) {
-      ["\(mod.moduleName.split(".").last).pkl"] = mod.moduleNode.output
+      ["\(mod.moduleName.split(".").takeLast(2).join("/")).pkl"] = mod.moduleNode.output
     }
   }
 }

--- a/packages/k8s.contrib.crd/internal/ModuleGenerator.pkl
+++ b/packages/k8s.contrib.crd/internal/ModuleGenerator.pkl
@@ -43,13 +43,13 @@ typealias CRD = CustomResourceDefinition|BetaCRD
 /// The CRD
 crd: CRD
 
+/// The CRD version to generate
+version: CustomResourceDefinition.CustomResourceDefinitionVersion|BetaCRD.CustomResourceDefinitionVersion
+
 logPaths: Boolean = false
 
 k8sImportPath: String
 
-// noinspection Deprecated
-local version: CustomResourceDefinition.CustomResourceDefinitionVersion|BetaCRD.CustomResourceDefinitionVersion =
-  crd.spec.versions.toList().find((version) -> version.storage)
 // noinspection Deprecated
 local schema: CustomResourceDefinition.CustomResourceValidation|BetaCRD.CustomResourceValidation =
   (if (crd is BetaCRD) version.schema ?? crd.spec.validation else version.schema)!!

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
@@ -1,5 +1,5 @@
 examples {
-  ["RestateCluster.pkl"] {
+  ["v1/RestateCluster.pkl"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -98,7 +98,7 @@ examples {
     
     """
   }
-  ["RestateCluster.pkl -- dependency notation for k8s"] {
+  ["v1/RestateCluster.pkl -- dependency notation for k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -197,7 +197,7 @@ examples {
     
     """
   }
-  ["RestateCluster.pkl -- different version of k8s"] {
+  ["v1/RestateCluster.pkl -- different version of k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///


### PR DESCRIPTION
Currently, the generator only generates the stored version. This changes the behvaior to generate for every other version.

As part of this change, the output path includes the version. For example, the output might produce the following:

* v1beta1/MyResource.pkl
* v1beta2/MyResource.pkl

Also: Bump k8s version to 1.2.0