### PR TITLE
[icalendar] Add package

### DIFF
--- a/packages/icalendar/PklProject
+++ b/packages/icalendar/PklProject
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// Library for working with iCalendar data.
+///
+/// Implements [RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545).
+amends "../basePklProject.pkl"
+
+package {
+  version = "0.1.0"
+}

--- a/packages/icalendar/PklProject.deps.json
+++ b/packages/icalendar/PklProject.deps.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 1,
+  "resolvedDependencies": {}
+}

--- a/packages/icalendar/tests/Recur.pkl
+++ b/packages/icalendar/tests/Recur.pkl
@@ -1,0 +1,196 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+module icalendar.tests.Recur
+amends "pkl:test"
+
+import "../type/Recur.pkl"
+import "../type/Date.pkl"
+import "../type/DateTime.pkl"
+
+facts {
+  ["with date"] {
+    new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      interval = 1
+      until = Date.Date("20250101")
+      byday {
+        "MO"
+        new { weeknum = -1; weekday = "FR" }
+      }
+      bymonthday { 15; -15 }
+      byyearday { 100; -100 }
+      bymonth { 1; 11 }
+      wkst = "MO"
+      bysetpos { -1; 1 }
+    }.toString() == """
+      DTSTART;VALUE=DATE:20000101
+      RRULE:FREQ=YEARLY;INTERVAL=1;UNTIL=20250101;BYDAY=MO,-1FR;BYMONTHDAY=15,-15;BYYEARDAY=100,-100;BYMONTH=1,11;WKST=MO;BYSETPOS=-1,1
+      """
+
+    // tzid not allowed for dates, only datetimes
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      tzid = "America/Los_Angeles"
+      freq = "YEARLY"
+    }.toString()) != null
+    module.catchOrNull(() -> new Recur {
+      tzid = "America/Los_Angeles"
+      freq = "YEARLY"
+      until = Date.Date("20250101")
+    }.toString()) != null
+
+    // until type must be date if dtstart is date
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      until = DateTime.DateTime("20250101T000000")
+    }.toString()) != null
+
+    // until and count forbidden together
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      count = 25
+      until = Date.Date("20250101")
+    }.toString()) != null
+
+    // bysecond cannot be used with date dtstart
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      bysecond { 0 }
+    }.toString()) != null
+
+    // byminute cannot be used with date dtstart
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      byminute { 0 }
+    }.toString()) != null
+
+    // byhour cannot be used with date dtstart
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      byhour { 0 }
+    }.toString()) != null
+
+    // bysetpos cannot be used without another by* property
+    module.catchOrNull(() -> new Recur {
+      dtstart = Date.Date("20000101")
+      freq = "YEARLY"
+      bysetpos { 1 }
+    }.toString()) != null
+  }
+
+  ["with datetime"] {
+    // utc
+    new Recur {
+      dtstart = DateTime.DateTime("20000101T000000Z")
+      freq = "YEARLY"
+      interval = 1
+      until = DateTime.DateTime("20250101T000000Z")
+      bysecond { 0; 30 }
+      byminute { 0; 30 }
+      byhour { 0; 12 }
+      byday {
+        "MO"
+        new { weeknum = -1; weekday = "FR" }
+      }
+      bymonthday { 15; -15 }
+      byyearday { 100; -100 }
+      bymonth { 1; 11 }
+      wkst = "MO"
+      bysetpos { -1; 1 }
+    }.toString() == """
+      DTSTART:20000101T000000Z
+      RRULE:FREQ=YEARLY;INTERVAL=1;UNTIL=20250101T000000Z;BYSECOND=0,30;BYMINUTE=0,30;BYHOUR=0,12;BYDAY=MO,-1FR;BYMONTHDAY=15,-15;BYYEARDAY=100,-100;BYMONTH=1,11;WKST=MO;BYSETPOS=-1,1
+      """
+
+    // floating
+    new Recur {
+      dtstart = DateTime.DateTime("20000101T000000")
+      freq = "YEARLY"
+      interval = 1
+      until = DateTime.DateTime("20250101T000000")
+      bysecond { 0; 30 }
+      byminute { 0; 30 }
+      byhour { 0; 12 }
+      byday {
+        "MO"
+        new { weeknum = -1; weekday = "FR" }
+      }
+      bymonthday { 15; -15 }
+      byyearday { 100; -100 }
+      bymonth { 1; 11 }
+      wkst = "MO"
+      bysetpos { -1; 1 }
+    }.toString() == """
+      DTSTART:20000101T000000
+      RRULE:FREQ=YEARLY;INTERVAL=1;UNTIL=20250101T000000;BYSECOND=0,30;BYMINUTE=0,30;BYHOUR=0,12;BYDAY=MO,-1FR;BYMONTHDAY=15,-15;BYYEARDAY=100,-100;BYMONTH=1,11;WKST=MO;BYSETPOS=-1,1
+      """
+
+    // with timezone
+    new Recur {
+      dtstart = DateTime.DateTime("20000101T000000")
+      tzid = "America/Los_Angeles"
+      freq = "YEARLY"
+      interval = 1
+      until = DateTime.DateTime("20250101T000000")
+      bysecond { 0; 30 }
+      byminute { 0; 30 }
+      byhour { 0; 12 }
+      byday {
+        "MO"
+        new { weeknum = -1; weekday = "FR" }
+      }
+      bymonthday { 15; -15 }
+      byyearday { 100; -100 }
+      bymonth { 1; 11 }
+      wkst = "MO"
+      bysetpos { -1; 1 }
+    }.toString() == """
+      DTSTART;TZID=America/Los_Angeles:20000101T000000
+      RRULE:FREQ=YEARLY;INTERVAL=1;UNTIL=20250101T000000;BYSECOND=0,30;BYMINUTE=0,30;BYHOUR=0,12;BYDAY=MO,-1FR;BYMONTHDAY=15,-15;BYYEARDAY=100,-100;BYMONTH=1,11;WKST=MO;BYSETPOS=-1,1
+      """
+
+    // forbid utc until with non-utc dtstart
+    module.catchOrNull(() -> new Recur {
+      dtstart = DateTime.DateTime("20000101T000000")
+      freq = "YEARLY"
+      until = DateTime.DateTime("20250101T000000Z")
+    }.toString()) != null
+    // forbid utc dtstart with non-utc until
+    module.catchOrNull(() -> new Recur {
+      dtstart = DateTime.DateTime("20000101T000000Z")
+      freq = "YEARLY"
+      until = DateTime.DateTime("20250101T000000")
+    }.toString()) != null
+    // forbid utc dtstart with tzid
+    module.catchOrNull(() -> new Recur {
+      dtstart = DateTime.DateTime("20000101T000000Z")
+      tzid = "America/Los_Angeles"
+      freq = "YEARLY"
+    }.toString()) != null
+    // forbid utc until with tzid
+    module.catchOrNull(() -> new Recur {
+      tzid = "America/Los_Angeles"
+      freq = "YEARLY"
+      until = DateTime.DateTime("20250101T000000Z")
+    }.toString()) != null
+  }
+}

--- a/packages/icalendar/type/Date.pkl
+++ b/packages/icalendar/type/Date.pkl
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// This value type is used to identify values that contain a calendar date.
+///
+/// https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.4
+module icalendar.type.Date
+
+import "Date.pkl"
+
+// language=Regexp
+const hidden dateRegex = "([0-9]{4})(0[1-9]|1[12])(0[1-9]|[12][0-9]|3[01])"
+typealias DateString = String(matches(Regex(dateRegex)))
+
+/// Year value.
+y: Int(isBetween(0, 9999))
+
+/// Month value.
+m: Int(isBetween(1, 12))
+
+/// Day value.
+d: Int(isBetween(1, 31))
+
+function toString(): String = List(
+  y.toString().padStart(4, "0"),
+  m.toString().padStart(2, "0"),
+  d.toString().padStart(2, "0")
+).join("")
+
+const function Date(input: DateString): Date = new {
+  y = input.substring(0, 4).toInt()
+  m = input.substring(4, 6).toInt()
+  d = input.substring(6, 8).toInt()
+}

--- a/packages/icalendar/type/DateTime.pkl
+++ b/packages/icalendar/type/DateTime.pkl
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// This value type is used to identify values that specify a precise calendar date and time of day.
+///
+/// https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.5
+module icalendar.type.DateTime
+
+import "Date.pkl"
+import "Time.pkl"
+import "DateTime.pkl"
+
+typealias DateTimeString = String(matches(Regex("\(Date.dateRegex)T\(Time.timeRegex)")))
+
+date: Date
+
+time: Time
+
+/// Indicates that [time] is UTC, not local.
+fixed utc: Boolean = time.utc
+
+function toString(): String = "\(date)T\(time)"
+
+/// Parse a [DateTimeString] into a [DateTime].
+const function DateTime(input: DateTimeString): DateTime = new {
+  local parts: List<String>(length == 2) = input.split("T")
+  date = Date.Date(parts.first)
+  time = Time.Time(parts.last)
+}

--- a/packages/icalendar/type/Recur.pkl
+++ b/packages/icalendar/type/Recur.pkl
@@ -1,0 +1,194 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// A recurrence rule.
+///
+/// https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10
+module icalendar.type.Recur
+
+import "Date.pkl"
+import "DateTime.pkl"
+
+typealias Frequency = "SECONDLY"|"MINUTELY"|"HOURLY"|"DAILY"|"WEEKLY"|"MONTHLY"|"YEARLY"
+
+typealias WeekdayString = "SU"|"MO"|"TU"|"WE"|"TH"|"FR"|"SA"
+
+class Weekday {
+  weekday: WeekdayString
+  weeknum: Int(this != 0)?
+
+  function toString(): String = List(
+    weeknum?.ifNonNull((n) -> if (n as Int > 0) "+" else ""),
+    weeknum?.toString(),
+    weekday
+  ).filterNonNull().join("")
+}
+
+typealias ByWeekday = WeekdayString|* Weekday
+
+dtstart: (
+  * DateTime(utc.implies(tzid == null))
+  |Date(tzid == null)
+  )?
+
+tzid: String?
+
+/// The FREQ rule part identifies the type of recurrence rule.
+freq: Frequency
+
+/// The INTERVAL rule part contains a positive integer representing at which intervals the recurrence rule repeats.
+///
+/// Defaults to 1 if not specified.
+interval: Int(this > 0)?
+
+/// The UNTIL rule part defines a DATE or DATE-TIME value that bounds the recurrence rule in an inclusive manner.
+///
+/// If the value specified by UNTIL is synchronized with the specified recurrence, this DATE or DATE-TIME becomes the last instance of the recurrence.
+/// If the "DTSTART" property is specified as a date with local time, then the UNTIL rule part MUST also be specified as a date with local time.
+/// If the "DTSTART" property is specified as a date with UTC time or a date with local time and time zone reference, then the UNTIL rule part MUST be specified as a date with UTC time.
+/// If not present, and the COUNT rule part is also not present, the "RRULE" is considered to repeat forever.
+until: (
+  * DateTime(
+      // if dtstart is defined and a datetime, until must also be a datetime if defined
+      dtstart?.ifNonNull((it) -> it is DateTime) ?? true,
+      dtstart?.ifNonNull((it) -> utc == (it as DateTime).utc) ?? true,
+      utc.implies(tzid == null)
+    )
+  |Date(
+    // if dtstart is defined and a date, until must also be a date if defined
+    dtstart?.ifNonNull((it) -> it is Date) ?? true,
+    tzid == null
+  )
+  )?
+
+/// The COUNT rule part defines the number of occurrences at which to range-bound the recurrence.
+///
+/// The "DTSTART" property value always counts as the first occurrence.
+count: Int(this > 0)?(
+    !(this != null && until != null) || throw("count and until may not both be set")
+  )
+
+/// The BYSECOND rule part specifies one or more seconds within a minute.
+bysecond: Listing<UInt(isBetween(0, 60))>(
+    !isEmpty,
+    !(dtstart is Date)
+  )?
+
+/// The BYMINUTE rule part specifies one or more minutes within an hour.
+byminute: Listing<UInt(isBetween(0, 59))>(
+    !isEmpty,
+    !(dtstart is Date)
+  )?
+
+/// The BYHOUR rule part specifies one or more hours of the day.
+byhour: Listing<UInt(isBetween(0, 23))>(
+    !isEmpty,
+    !(dtstart is Date)
+  )?
+
+/// The BYDAY rule part specifies one or more days of the week.
+///
+/// Each BYDAY value can also be preceded by a positive (+n) or negative (-n) integer.
+/// If present, this indicates the nth occurrence of a specific day within the MONTHLY or YEARLY "RRULE".
+/// For example, within a MONTHLY rule, +1MO (or simply 1MO) represents the first Monday within the month, whereas -1MO represents the last Monday of the month.
+/// The numeric value in a BYDAY rule part with the FREQ rule part set to YEARLY corresponds to an offset within the month when the BYMONTH rule part is present, and corresponds to an offset within the year when the BYWEEKNO or BYMONTH rule parts are present.
+///
+/// If an integer modifier is not present, it means all days of this type within the specified frequency.
+/// For example, within a MONTHLY rule, MO represents all Mondays within the month.
+byday: Listing<ByWeekday>(
+    !isEmpty,
+    freq == "MONTHLY" || freq == "YEARLY",
+    !(freq == "YEARLY" && byweekno != null)
+  )?
+
+/// The BYMONTHDAY rule part specifies one or more days of the month.
+///
+/// Negative values represent days counting back from the end of a month.
+/// For example, -10 represents the tenth to the last day of the month.
+bymonthday: Listing<Int(isBetween(-31, 31), this != 0)>(
+    !isEmpty,
+    freq != "MONTHLY"
+  )?
+
+/// The BYYEARDAY rule part specifies one or more days of the year.
+///
+/// Negative values represent days counting back from the end of a year.
+/// For example, -1 represents the last day of the year (December 31st) and -306 represents the 306th to the last day of the year (March 1st).
+byyearday: Listing<Int(isBetween(-366, 366), this != 0)>(
+    !isEmpty,
+    freq != "DAILY",
+    freq != "WEEKLY",
+    freq != "MONTHLY"
+  )?
+
+/// The BYWEEKNO rule part specifies one or more ordinals specifying weeks of the year.
+///
+/// This corresponds to weeks according to week numbering as defined in [ISO.8601.2004](https://datatracker.ietf.org/doc/html/rfc5545#ref-ISO.8601.2004).
+/// A week is defined as a seven day period, starting on the day of the week defined to be the week start (see [wkst]).
+/// Week number one of the calendar year is the first week that contains at least four (4) days in that calendar year.
+///
+/// Note: Assuming a Monday week start, week 53 can only occur when Thursday is January 1 or if it is a leap year and Wednesday is January 1.
+byweekno: Listing<Int(isBetween(-53, 53), this != 0)>(
+    !isEmpty,
+    freq == "YEARLY"
+  )?
+
+/// The BYMONTH rule part specifies one or more months of the year.
+bymonth: Listing<UInt(isBetween(1, 12))>(!isEmpty)?
+
+/// The WKST rule part specifies the day on which the workweek starts.
+///
+/// This is significant when a WEEKLY "RRULE" has an interval greater than 1, and a BYDAY rule part is specified.
+/// This is also significant when in a YEARLY "RRULE" when a BYWEEKNO rule part is specified.
+/// Defaults to "MO" if not specified.
+wkst: WeekdayString?
+
+/// The BYSETPOS rule part specifies one or more values that corresponds to the nth occurrence within the set of recurrence instances specified by the rule.
+///
+/// BYSETPOS operates on a set of recurrence instances in one interval of the recurrence rule.
+/// For example, in a WEEKLY rule, the interval would be one week A set of recurrence instances starts at the beginning of the interval defined by the FREQ rule part.
+bysetpos: Listing<Int(isBetween(-366, 366), this != 0)>(
+    !isEmpty,
+    List(bysecond, byminute, byhour, byday, bymonthday, byyearday, byweekno, bymonth)
+      .filterNonNull().length > 0 // RFC is a little ambiguous on this one, should it be >0 or ==1?
+  )?
+
+/// Serialize the recurrence rule.
+///
+/// Note: this departs from the RFC around line lengths.
+/// The 75-character line limit and folding behavior are not enforced.
+/// Lines are separated by "\n" (LF) and not "\r\n" (CRLF).
+/// Ref: https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
+function toString(): String = List(
+  dtstart?.ifNonNull((start) -> List(
+    "DTSTART",
+    if (dtstart is Date) ";VALUE=DATE" else null,
+    tzid?.ifNonNull((tz) -> ";TZID=\(tz)"),
+    ":\(start)"
+  ).filterNonNull().join("")),
+  let (parts = module.toMap()
+    .remove("tzid").remove("dtstart")
+    .filter((_, v) -> v != null)
+    .entries.map((entry) ->
+    let (value = if (entry.value is Listing)
+      // https://github.com/apple/pkl/issues/923 :(
+      // entry.value.join(",")
+      entry.value.toList().map((it) -> it.toString()).join(",")
+    else entry.value.toString())
+      "\(entry.key.toUpperCase())=\(value)"
+  )
+  )
+    if (!parts.isEmpty) "RRULE:\(parts.join(";"))" else null
+).filterNonNull().join("\n")

--- a/packages/icalendar/type/Time.pkl
+++ b/packages/icalendar/type/Time.pkl
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// This value type is used to identify values that contain a time of day.
+///
+/// https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.12
+module icalendar.type.Time
+
+import "Time.pkl"
+
+// language=Regexp
+const hidden timeRegex = "([01][0-9]|2[0-3])([0-5][0-9])([0-5][0-9]|60)Z?"
+typealias TimeString = String(matches(Regex(timeRegex)))
+
+/// Hour value.
+h: Int(isBetween(0, 23))
+
+/// Minute value.
+m: Int(isBetween(0, 59))
+
+/// Seconds value.
+///
+/// A value of 60 allows accounting for positive leap seconds.
+s: Int(isBetween(0, 60))
+
+/// Indicates that the time is UTC, not local.
+utc: Boolean
+
+function toString(): String = List(
+  h.toString().padStart(2, "0"),
+  m.toString().padStart(2, "0"),
+  s.toString().padStart(2, "0"),
+  if (utc) "Z" else ""
+).join("")
+
+/// Parse a [TimeString] into a [Time].
+const function Time(input: TimeString): Time = new {
+  h = input.substring(0, 2).toInt()
+  m = input.substring(2, 4).toInt()
+  s = input.substring(4, 6).toInt()
+  utc = input.getOrNull(6) == "Z"
+}


### PR DESCRIPTION
This PR introduces functionality for handling [RFC 5545 Recurrence Rules](https://datatracker.ietf.org/doc/html/rfc5545#autoid-42).
In general, attempts are made to conform strictly to the RFC where possible, but there are some small deviations.

Included functionality:
* Modules representing the `DATE`, `DATE-TIME`, `RECUR`, and `TIME` property value data types
* Rendering of each of these types to their serialized form via `toString()`
* Parsing of `Date`, `DateTime`, and `Time` objects from their string representations

Omitted functionality that can be added in the future:
* Parsing of `Recur` objects from their string representations
* Support for other structured property value data types
* Support for calendar objects or specific calendar components (eg. events, to-dos, alarms, etc.)