### PR TITLE
Improve error message provided on conversion failure

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "3.0.0"
+  version = "3.0.1"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.1",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.0"
+  version = "1.1.1"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -30,7 +30,7 @@ function apply(type: Class|TypeAlias, value: Any): Any =
   let (result =
     attemptApply(type, value)
   )
-    if (result is ConversionFailure) throw(result.Error) else result
+    if (result is ConversionFailure) throw(result.error) else result
 
 /// Same as [apply], but returns [ConversionFailure] rather than throwing.
 function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure =

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -30,7 +30,7 @@ function apply(type: Class|TypeAlias, value: Any): Any =
   let (result =
     attemptApply(type, value)
   )
-    if (result is ConversionFailure) throw(result.message) else result
+    if (result is ConversionFailure) throw(result.Error) else result
 
 /// Same as [apply], but returns [ConversionFailure] rather than throwing.
 function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure =
@@ -41,10 +41,26 @@ function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure 
 
 
 class ConversionFailure {
+  fixed Error = "\(message) at \n\(renderedPath)"
   message: String
+  path: Listing<String|Int>
+
+  local renderedPath = path.toList().reverse().fold("", (acc, v) ->
+    if (v is String) "\(acc).\(v)" else "\(acc)[\(v)]"
+  )
 
   function toMapping(): ConversionFailure = this
   function toListing(): ConversionFailure = this
+  function appendPath(_path: String) = (this) {
+    path {
+      _path
+    }
+  }
+  function appendIndex(idx: Int) = (this) {
+    path {
+      idx
+    }
+  }
 }
 
 function Fail(_message: String): ConversionFailure = new {
@@ -145,7 +161,7 @@ local function applyDynamicOrMapping(type: reflect.Class, value: Dynamic|Mapping
             acc
           else
             let (result = applyProperty(valueAsMap, prop))
-              if (result is ConversionFailure) result else acc.put(name, result)
+              if (result is ConversionFailure) result.appendPath(name) else acc.put(name, result)
       )
     )
       if (converted is ConversionFailure) converted else converted.toTyped(type.reflectee)
@@ -226,9 +242,9 @@ local function applyMapping(keyType: reflect.Type, valueType: reflect.Type, valu
   applyMap(keyType, valueType, value).toMapping()
 
 local function applyList(type: reflect.Type, value: Dynamic|Collection): List|ConversionFailure =
-  value.toList().fold(List(), (acc: List|ConversionFailure, v) -> if (acc is ConversionFailure) acc else
+  value.toList().foldIndexed(List(), (idx: Int, acc: List|ConversionFailure, v) -> if (acc is ConversionFailure) acc else
     let (_v = applyType(type, v))
-      if (_v is ConversionFailure) _v else
+      if (_v is ConversionFailure) _v.appendIndex(idx) else
         acc.add(_v)
   )
 

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -41,7 +41,7 @@ function attemptApply(type: Class|TypeAlias, value: Any): Any|ConversionFailure 
 
 
 class ConversionFailure {
-  fixed Error = "\(message) at \n\(renderedPath)"
+  fixed error = "\(message) (at path \(renderedPath))"
   message: String
   path: Listing<String|Int>
 

--- a/packages/pkl.experimental.structuredRead/PklProject
+++ b/packages/pkl.experimental.structuredRead/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ amends ".../basePklProject.pkl"
 
 
 package {
-  version = "1.0.3"
+  version = "1.0.4"
 }
 
 dependencies {

--- a/packages/pkl.experimental.structuredRead/PklProject.deps.json
+++ b/packages/pkl.experimental.structuredRead/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.1.1",
       "path": "../pkl.experimental.deepToTyped"
     }
   }


### PR DESCRIPTION
When a conversion failure occurs deepToTyped creates a path to the location of the failure in the object that's undergoing conversion. Now the error indicates both the type and location of the error making it much easier to debug problems.

Example of previous error:

```
    Expected "String" but got "Dynamic"
```

Example of new error:

```
    Expected "String" but got "Dynamic" at 
    .metadata.managedFields[0].fieldsV1
```