### PR TITLE
Turn `findValueEndIndex` into an iterative function to reduce stack overflows

### DIFF
--- a/packages/pkl.csv/PklProject
+++ b/packages/pkl.csv/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.1.0"
 }

--- a/packages/pkl.csv/csv.pkl
+++ b/packages/pkl.csv/csv.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -254,14 +254,21 @@ local class StringyTableParser {
                       }.parseResult
 
   function findValueEndIndex(position: UInt): UInt =
-    let (characterAtPosition = input.getOrNull(position))
-      if (characterAtPosition == "\"")
-        if (input.getOrNull(position + 1) == "\"")
-          findValueEndIndex(position + 2)
-        else
-          position
-      else if (characterAtPosition == null)
-        throw("Premature end of quoted field")
-      else
-        findValueEndIndex(position + 1)
+    let (remainingPositions = IntSeq(position, input.length - 1))
+      remainingPositions.fold(Pair(position, false), (state, currentPos) ->
+        let (searchPos = state.first)
+          let (found = state.second)
+            if (found || currentPos < searchPos)
+              state  // Already found or haven't reached search position yet
+            else
+              let (characterAtPosition = input.getOrNull(currentPos))
+                new Mapping {
+                  ["\""] =
+                    if (input.getOrNull(currentPos + 1) == "\"")
+                      Pair(currentPos + 2, false)  // Escaped quote, skip ahead by 2
+                    else
+                      Pair(currentPos, true)  // Found unescaped quote, this is the end
+                  [null] = throw("Premature end of quoted field")
+                }.getOrNull(characterAtPosition) ?? Pair(currentPos + 1, false)  // Continue searching, advance by 1
+      ).first
 }

--- a/packages/pkl.csv/csv.pkl
+++ b/packages/pkl.csv/csv.pkl
@@ -57,7 +57,7 @@ class Renderer extends ValueRenderer {
     else
       throw("The CSV renderer only supports primitive values in `renderValue`.")
 
-function renderDocument(value: Any) =
+  function renderDocument(value: Any) =
     let (table =
       if (value is ListLike?)
         (value as ListLike? ?? List()).toList()
@@ -119,7 +119,7 @@ function renderDocument(value: Any) =
   ///  - `"pad"` gathers property names from the entire table and inserts (pads) empty values when properties are missing.
   ///
   /// (Default: `"error"`)
-  unification: *"error"|"drop"|"pad"
+  unification: * "error"|"drop"|"pad"
 
   /// Tells whether to include a (first) line with the names of the columns.
   includeHeader: Boolean = true
@@ -153,14 +153,13 @@ class Parser {
     [Boolean] = (it) -> it.toBoolean()
   }
 
-  function parse(source: Resource|String):
-    List<Dynamic>(rowClass == null)|List<Typed(getClass() == rowClass)>(rowClass != null) =
+  function parse(source: Resource|String): List<Dynamic>(rowClass == null)|List<Typed(getClass() == rowClass)>(rowClass != null) =
     (this) { input = if (source is String) source else source.text }.parsed
 
   /// The result of parsing [input] as CSV.
   ///
   /// This is a "final" property, because it is derived from the input properties [input], [includeHeader] and [rowClass].
-  parsed: (*List<Dynamic>(rowClass == null)|List<Typed(getClass() == rowClass)>(rowClass != null))(this == _parsed) =
+  parsed: (* List<Dynamic>(rowClass == null)|List<Typed(getClass() == rowClass)>(rowClass != null))(this == _parsed) =
     _parsed
 
   local function convert(type: reflect.Type|Class|TypeAlias): (String) -> unknown =
@@ -184,7 +183,7 @@ class Parser {
         input = self.input
         lineBreak = self.lineBreak
       }.parseResult.rows.toList())
-        let (properties: Map<String,reflect.Property>? = rowClass.ifNonNull((clazz) -> allProps(reflect.Class(clazz as Class))))
+        let (properties: Map<String, reflect.Property>? = rowClass.ifNonNull((clazz) -> allProps(reflect.Class(clazz as Class))))
           let (header: List<String>? = (if (includeHeader) stringyResult[0] else properties?.keys)?.toList() as List<String>?)
             if (header == null) stringyResult.map((rawRow) -> rawRow.toDynamic()) else
               stringyResult.toList().drop(if (includeHeader) 1 else 0).map((rawRow) ->


### PR DESCRIPTION
Tested with:

```
❯ java -Xss1800k -jar ./jpkl -v
Pkl 0.28.2 (macOS 15.0, Java 23.0.2)

❯ java -Xss1800k -jar ./jpkl eval test.pkl
```

Specifically to take care of this issue under `jpkl` which isn't
present under `pkl`:

```
–– Pkl Error ––
A stack overflow occurred.

┌─ 3 repetitions of:
│ 267 | findValueEndIndex(position + 1)
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.findValueEndIndex.<function#1> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 258 | let (characterAtPosition = input.getOrNull(position))
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.findValueEndIndex (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
└─

226 | findValueEndIndex(idxValueStart)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at pkl.csv.csv#StringyTableParser.parseResult.<function#2> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)

┌─ 284 repetitions of:
│
│ 245 | (this) {
│       ^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#8> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 238 | let (newRow = (currentRow) {
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#7> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 237 | let (value = input.substring(idxValueStart, idxValueEnd))
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#6> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 235 | let (nullEnd = delimiter == "," && idxFieldEnd == input.length - 1)
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#5> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 232 | let (delimiter = input.getOrNull(idxFieldEnd))
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#4> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 231 | let (idxFieldEnd = idxValueEnd + if (isEscapedField) 1 else 0)
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#3> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 222 | let (idxValueEnd =
│       ^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#2> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 221 | let (idxValueStart = if (isEscapedField) position + 1 else position)
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult.<function#1> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
│
│ 219 | let (isEscapedField = input.getOrNull(position) == "\"")
│       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│ at pkl.csv.csv#StringyTableParser.parseResult (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)
└─

182 | let (stringyResult = new StringyTableParser {
                           ^^^^^^^^^^^^^^^^^^^^^^^^
at pkl.csv.csv#Parser._parsed.<function#1> (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)

181 | let (self = this)
      ^^^^^^^^^^^^^^^^^
at pkl.csv.csv#Parser._parsed (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)

164 | _parsed
      ^^^^^^^
at pkl.csv.csv#Parser.parsed (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)

158 | (this) { input = if (source is String) source else source.text }.parsed
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at pkl.csv.csv#Parser.parse (projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.csv@1.0.0#/csv.pkl)

3 | reportData = reportParser.parse(read(reportFileName)) as List<Report>
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at test#reportData (file:///tmp/test.pkl:3:19)

106 | text = renderer.renderDocument(value)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
at pkl.base#Module.output.text (https://github.com/apple/pkl/blob/0.28.2/stdlib/base.pkl#L106)
```