### PR TITLE
[k8s.contrib.crd] Fix handling of apiGroup directories

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "3.0.2"
+  version = "4.0.0"
 }

--- a/packages/k8s.contrib.crd/generate.pkl
+++ b/packages/k8s.contrib.crd/generate.pkl
@@ -80,7 +80,9 @@ k8sVersion: String(semver.isValid(this)) = "1.0.1"
 /// // Use dependency notation, assuming the dependency is called `@k8s`.
 /// k8sImportPath = "@k8s"
 /// ```
-k8sImportPath: String = "package://pkg.pkl-lang.org/pkl-k8s/k8s@\(k8sVersion)#"
+k8sImportPath: String = read?("prop:k8sImportPath") ?? "package://pkg.pkl-lang.org/pkl-k8s/k8s@\(k8sVersion)#"
+
+baseApiGroup: String = read?("prop:baseApiGroup") ?? "k8s.io"
 
 /// Where to find the CRDs; can be a URI (`https:`, `file:` etc), an absolute file path, or a relative file path
 source: String = read("prop:source")
@@ -150,7 +152,7 @@ output {
   text = throw("The JSON Schema generator only works with multiple-file output. Try running again with the -m option.")
   files {
     for (mod in modules) {
-      ["\(mod.moduleName.split(".").takeLast(2).join("/")).pkl"] = mod.moduleNode.output
+      ["\(mod.moduleName.replaceFirst(Regex(#"^\#(baseApiGroup)\."#), "").split(".").join("/")).pkl"] = mod.moduleNode.output
     }
   }
 }

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl
@@ -72,4 +72,14 @@ examples {
       value.text
     }
   }
+
+  ["apiGroup subdomains"] {
+    for (path, value in (generate) {
+      sourceContents = read("fixtures/crds_subdomain.yaml")
+      source = "dummy://test_uri"
+      baseApiGroup = "bar"
+    }.output.files!!) {
+      Pair(path, value.value.declaration.moduleHeader.name.parts.toList().map((it) -> it.value).join("."))
+    }
+  }
 }

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
@@ -1,5 +1,5 @@
 examples {
-  ["v1/RestateCluster.pkl"] {
+  ["dev/restate/v1/RestateCluster.pkl"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -98,7 +98,7 @@ examples {
     
     """
   }
-  ["v1/RestateCluster.pkl -- dependency notation for k8s"] {
+  ["dev/restate/v1/RestateCluster.pkl -- dependency notation for k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -197,7 +197,7 @@ examples {
     
     """
   }
-  ["v1/RestateCluster.pkl -- different version of k8s"] {
+  ["dev/restate/v1/RestateCluster.pkl -- different version of k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -373,5 +373,9 @@ examples {
     }
     
     """
+  }
+  ["apiGroup subdomains"] {
+    Pair("v1/Foo.pkl", "bar.v1.Foo")
+    Pair("baz/v1/Qux.pkl", "bar.baz.v1.Qux")
   }
 }

--- a/packages/k8s.contrib.crd/tests/fixtures/crds_subdomain.yaml
+++ b/packages/k8s.contrib.crd/tests/fixtures/crds_subdomain.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foo.bar.com
+spec:
+  group: bar
+  names:
+    categories: []
+    kind: Foo
+    plural: foo
+    singular: foo
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns: []
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            foo:
+              properties:
+                redObject:
+                  description: Test nested objects field collision.
+                  properties:
+                    nestedField:
+                      description: Nested field.
+                      type: string
+                    nestedObject:
+                      description: Nested child object.
+                      properties:
+                        nestedRed:
+                          description: Nested field.
+                          type: string
+                      type: object
+                    nestedList:
+                      description: Nested list object red.
+                      items:
+                        description: Red nested object test items.
+                        properties:
+                          nestedListItemField:
+                            description: Red nested list field.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                    - nestedField
+                  type: object
+                blueObject:
+                  description: Test nested objects field collision.
+                  properties:
+                    nestedField:
+                      description: Nested field.
+                      type: string
+                    nestedObject:
+                      description: Nested child object.
+                      properties:
+                        nestedBlue:
+                          description: Nested field.
+                          type: string
+                      type: object
+                    nestedList:
+                      description: Nested list object blue.
+                      items:
+                        description: Blue nested object test items.
+                        properties:
+                          nestedListItemField:
+                            description: Blue nested list field.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                    - nestedField
+                  type: object
+              required:
+                - image
+              type: object
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: qux.baz.bar.com
+spec:
+  group: baz.bar
+  names:
+    categories: []
+    kind: Qux
+    plural: quz
+    singular: Qux
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns: []
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            foo:
+              properties:
+                redObject:
+                  description: Test nested objects field collision.
+                  properties:
+                    nestedField:
+                      description: Nested field.
+                      type: string
+                    nestedObject:
+                      description: Nested child object.
+                      properties:
+                        nestedRed:
+                          description: Nested field.
+                          type: string
+                      type: object
+                    nestedList:
+                      description: Nested list object red.
+                      items:
+                        description: Red nested object test items.
+                        properties:
+                          nestedListItemField:
+                            description: Red nested list field.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                    - nestedField
+                  type: object
+                blueObject:
+                  description: Test nested objects field collision.
+                  properties:
+                    nestedField:
+                      description: Nested field.
+                      type: string
+                    nestedObject:
+                      description: Nested child object.
+                      properties:
+                        nestedBlue:
+                          description: Nested field.
+                          type: string
+                      type: object
+                    nestedList:
+                      description: Nested list object blue.
+                      items:
+                        description: Blue nested object test items.
+                        properties:
+                          nestedListItemField:
+                            description: Blue nested list field.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                    - nestedField
+                  type: object
+              required:
+                - image
+              type: object
+      served: true
+      storage: true


### PR DESCRIPTION
This also exposes `k8sImportPath` as a property