### PR TITLE
Add labels field to Prometheus rule groups

### DIFF
--- a/packages/io.prometheus/PklProject
+++ b/packages/io.prometheus/PklProject
@@ -18,5 +18,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.3.0"
+  version = "1.4.0"
 }

--- a/packages/io.prometheus/Rule.pkl
+++ b/packages/io.prometheus/Rule.pkl
@@ -47,6 +47,10 @@ class RecordingRuleGroup {
   /// Limit the number of alerts an alerting rule and series a recording rule can produce.
   limit: Int?
 
+  /// Labels to add or overwrite before storing the result for its rules.
+  /// Labels defined in RecordingRule will override the key if it has a collision.
+  labels: Labels?
+
   rules: Listing<RecordingRule>
 }
 
@@ -62,6 +66,10 @@ class AlertingRuleGroup {
 
   /// Limit the number of alerts an alerting rule and series a recording rule can produce.
   limit: Int?
+
+  /// Labels to add or overwrite before storing the result for its rules.
+  /// Labels defined in AlertingRule will override the key if it has a collision.
+  labels: Labels?
 
   rules: Listing<AlertingRule>
 }

--- a/packages/io.prometheus/Rule.pkl
+++ b/packages/io.prometheus/Rule.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,8 @@ class RecordingRuleGroup {
   limit: Int?
 
   /// Labels to add or overwrite before storing the result for its rules.
-  /// Labels defined in RecordingRule will override the key if it has a collision.
+  ///
+  /// Labels defined in [RecordingRule] will override the key if it has a collision.
   labels: Labels?
 
   rules: Listing<RecordingRule>
@@ -68,7 +69,8 @@ class AlertingRuleGroup {
   limit: Int?
 
   /// Labels to add or overwrite before storing the result for its rules.
-  /// Labels defined in AlertingRule will override the key if it has a collision.
+  ///
+  /// Labels defined in [AlertingRule] will override the key if it has a collision.
   labels: Labels?
 
   rules: Listing<AlertingRule>

--- a/packages/io.prometheus/examples/rule.pkl
+++ b/packages/io.prometheus/examples/rule.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/io.prometheus/examples/rule.pkl
+++ b/packages/io.prometheus/examples/rule.pkl
@@ -21,6 +21,9 @@ groups {
   new AlertingRuleGroup {
     name = "alerting_rules"
     interval = 5.min
+    labels {
+      ["group"] = "alerts"
+    }
     rules {
       new {
         alert = "HighRequestLatency"
@@ -40,6 +43,9 @@ groups {
   new RecordingRuleGroup {
     name = "recording_rules"
     interval = 10.h
+    labels {
+      ["group"] = "recording"
+    }
     rules {
       new {
         `record` = "job:http_inprogress_requests:sum"

--- a/packages/io.prometheus/tests/rule.pkl-expected.pcf
+++ b/packages/io.prometheus/tests/rule.pkl-expected.pcf
@@ -4,6 +4,8 @@ examples {
     groups:
     - name: alerting_rules
       interval: 5m
+      labels:
+        group: alerts
       rules:
       - alert: HighRequestLatency
         expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
@@ -16,6 +18,8 @@ examples {
           summary: High request latency
     - name: recording_rules
       interval: 10h
+      labels:
+        group: recording
       rules:
       - record: job:http_inprogress_requests:sum
         expr: sum by (job) (http_inprogress_requests)


### PR DESCRIPTION
Prometheus has added the labels field to alerting and recording rule groups and it's quite useful.
See https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group