### PR TITLE
[k8s.contrib.crd] Add generation of k8sSchema module

### DIFF
--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "4.0.0"
+  version = "4.1.0"
 }

--- a/packages/k8s.contrib.crd/generate.pkl
+++ b/packages/k8s.contrib.crd/generate.pkl
@@ -83,8 +83,14 @@ k8sVersion: String(semver.isValid(this)) = "1.0.1"
 /// ```
 k8sImportPath: String = read?("prop:k8sImportPath") ?? "package://pkg.pkl-lang.org/pkl-k8s/k8s@\(k8sVersion)#"
 
+/// The base API group.
+///
+/// Used to determine the output directory structure and which parts should be included in the path.
 baseApiGroup: String = read?("prop:baseApiGroup") ?? "k8s.io"
 local baseApiGroupModulePrefix = baseApiGroup.split(".").reverse().join(".")
+
+/// Enable or disable generating a k8sSchema.pkl at the root of the output.
+generateSchema: Boolean = read?("prop:generateSchema")?.toBoolean() ?? false
 
 /// Where to find the CRDs; can be a URI (`https:`, `file:` etc), an absolute file path, or a relative file path
 source: String = read("prop:source")
@@ -151,6 +157,7 @@ fixed modules: Listing<ModuleGenerator> = new {
 }
 
 fixed schema: SchemaGenerator = new {
+  k8sImportPath = module.k8sImportPath
   crds = _crds
   baseApiGroup = module.baseApiGroup
 }
@@ -158,7 +165,9 @@ fixed schema: SchemaGenerator = new {
 output {
   text = throw("The JSON Schema generator only works with multiple-file output. Try running again with the -m option.")
   files {
-    ["k8sSchema.pkl"] = schema.moduleNode.output
+    when (generateSchema) {
+      ["k8sSchema.pkl"] = schema.moduleNode.output
+    }
     for (mod in modules) {
       ["\(mod.moduleName.replaceFirst(Regex(#"^\#(baseApiGroupModulePrefix)\."#), "").split(".").join("/")).pkl"] = mod.moduleNode.output
     }

--- a/packages/k8s.contrib.crd/generate.pkl
+++ b/packages/k8s.contrib.crd/generate.pkl
@@ -64,6 +64,7 @@ import "@deepToTyped/deepToTyped.pkl"
 import "@uri/URI.pkl"
 
 import "internal/ModuleGenerator.pkl"
+import "internal/SchemaGenerator.pkl"
 
 /// The version of the Pkl Kubernetes package to import.
 ///
@@ -83,6 +84,7 @@ k8sVersion: String(semver.isValid(this)) = "1.0.1"
 k8sImportPath: String = read?("prop:k8sImportPath") ?? "package://pkg.pkl-lang.org/pkl-k8s/k8s@\(k8sVersion)#"
 
 baseApiGroup: String = read?("prop:baseApiGroup") ?? "k8s.io"
+local baseApiGroupModulePrefix = baseApiGroup.split(".").reverse().join(".")
 
 /// Where to find the CRDs; can be a URI (`https:`, `file:` etc), an absolute file path, or a relative file path
 source: String = read("prop:source")
@@ -106,7 +108,7 @@ sourceContents: String|Resource = read(URI.encode(sourceUri))
 /// Default: `false`.
 logPaths: Boolean? = read?("prop:logPaths")?.toBoolean()
 
-local crds: Listing<ModuleGenerator.CRD> =
+local _crds: Listing<ModuleGenerator.CRD> =
   let (parser = new yaml.Parser { useMapping = true })
     new {
       for (crd in parser.parseAll(sourceContents)) {
@@ -134,7 +136,7 @@ local crds: Listing<ModuleGenerator.CRD> =
 converters: Mapping<String, Mapping<List<String>, Module|Class|TypeAlias>>?
 
 fixed modules: Listing<ModuleGenerator> = new {
-  for (_crd in crds) {
+  for (_crd in _crds) {
     for (_version in _crd.spec.versions) {
       new ModuleGenerator {
         k8sImportPath = module.k8sImportPath
@@ -148,11 +150,17 @@ fixed modules: Listing<ModuleGenerator> = new {
   }
 }
 
+fixed schema: SchemaGenerator = new {
+  crds = _crds
+  baseApiGroup = module.baseApiGroup
+}
+
 output {
   text = throw("The JSON Schema generator only works with multiple-file output. Try running again with the -m option.")
   files {
+    ["k8sSchema.pkl"] = schema.moduleNode.output
     for (mod in modules) {
-      ["\(mod.moduleName.replaceFirst(Regex(#"^\#(baseApiGroup)\."#), "").split(".").join("/")).pkl"] = mod.moduleNode.output
+      ["\(mod.moduleName.replaceFirst(Regex(#"^\#(baseApiGroupModulePrefix)\."#), "").split(".").join("/")).pkl"] = mod.moduleNode.output
     }
   }
 }

--- a/packages/k8s.contrib.crd/internal/SchemaGenerator.pkl
+++ b/packages/k8s.contrib.crd/internal/SchemaGenerator.pkl
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+module k8s.contrib.crd.internal.SchemaGenerator
+
+import "@syntax/ModuleNode.pkl"
+import "@syntax/TypeNode.pkl"
+import "@syntax/ExpressionNode.pkl"
+import "@syntax/ObjectBodyNode.pkl"
+import "ModuleGenerator.pkl"
+
+baseApiGroup: String
+
+crds: Listing<ModuleGenerator.CRD>
+
+fixed moduleNode: ModuleNode = new {
+  declaration {
+    moduleHeader {
+      name {
+        parts {
+          for (part in baseApiGroup.split(".").reverse()) {
+            new { value = part }
+          }
+          new { value = "k8sSchema" }
+        }
+      }
+    }
+  }
+  properties {
+    new {
+      name { value = "resourceTemplates" }
+      typeAnnotation {
+        type = new TypeNode.DeclaredTypeNode {
+          name { parts { new { value = "Mapping" } } }
+          typeArguments {
+            new TypeNode.DeclaredTypeNode {
+              name { parts { new { value = "String" } } }
+            }
+            new TypeNode.DeclaredTypeNode {
+              name { parts { new { value = "Mapping" } } }
+              typeArguments {
+                new TypeNode.DeclaredTypeNode {
+                  name { parts { new { value = "String" } } }
+                }
+                new TypeNode.BuiltInTypeNode { type = "unknown" }
+              }
+            }
+          }
+        }
+      }
+      docComment {
+        value = """
+          Resource modules keyed by `kind` and `apiVersion`.
+
+          Note: Declared template type is [unknown] instead of `K8sResource`
+          to delay loading a template until it is accessed.
+          """
+      }
+      defaultValue = new ExpressionNode.ObjectExpressionNode {
+        body {
+          members {
+            for (crd in crds) {
+              new ObjectBodyNode.EntryMemberNode {
+                keyValue = new ExpressionNode.StringExpressionNode {
+                  stringParts { crd.spec.names.kind }
+                }
+                body {
+                  members {
+                    for (version in crd.spec.versions) {
+                      new ObjectBodyNode.EntryMemberNode {
+                        keyValue = new ExpressionNode.StringExpressionNode {
+                          stringParts { "\(crd.spec.group)/\(version.name)" }
+                        }
+                        propertyValue = new ExpressionNode.ImportExpressionNode {
+                          value = let (groupComponent = crd.spec.group.replaceFirst(Regex(#"(^|\.)\#(baseApiGroup)$"#), ""))
+                              if (groupComponent.isEmpty) "\(version.name)/\(crd.spec.names.kind)"
+                              else "\(groupComponent.split(".").reverse().join("/"))/\(version.name)/\(crd.spec.names.kind)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/k8s.contrib.crd/internal/SchemaGenerator.pkl
+++ b/packages/k8s.contrib.crd/internal/SchemaGenerator.pkl
@@ -25,6 +25,8 @@ baseApiGroup: String
 
 crds: Listing<ModuleGenerator.CRD>
 
+k8sImportPath: String
+
 fixed moduleNode: ModuleNode = new {
   declaration {
     moduleHeader {
@@ -37,6 +39,9 @@ fixed moduleNode: ModuleNode = new {
         }
       }
     }
+  }
+  imports {
+    new { value = "\(k8sImportPath)/K8sResource.pkl" }
   }
   properties {
     new {
@@ -54,7 +59,9 @@ fixed moduleNode: ModuleNode = new {
                 new TypeNode.DeclaredTypeNode {
                   name { parts { new { value = "String" } } }
                 }
-                new TypeNode.BuiltInTypeNode { type = "unknown" }
+                new TypeNode.DeclaredTypeNode {
+                  name { parts { new { value = "K8sResource" } } }
+                }
               }
             }
           }
@@ -63,9 +70,6 @@ fixed moduleNode: ModuleNode = new {
       docComment {
         value = """
           Resource modules keyed by `kind` and `apiVersion`.
-
-          Note: Declared template type is [unknown] instead of `K8sResource`
-          to delay loading a template until it is accessed.
           """
       }
       defaultValue = new ExpressionNode.ObjectExpressionNode {

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl
@@ -26,6 +26,7 @@ import "../generate.pkl"
 local generator = (generate) {
   sourceContents = read("fixtures/crds.yaml")
   source = "dummy://test_uri"
+  baseApiGroup = "restate.dev"
   converters {
     ["restateclusters.restate.dev"] {
       [List("spec", "compute", "env", "[]")] = EnvVar
@@ -67,6 +68,7 @@ examples {
   ["conflicting schemas"] {
     for (_, value in (generate) {
       sourceContents = read("fixtures/crds_conflict.yaml")
+      baseApiGroup = "bar.com"
       source = "dummy://test_uri"
     }.output.files!!) {
       value.text

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
@@ -1,5 +1,21 @@
 examples {
-  ["dev/restate/v1/RestateCluster.pkl"] {
+  ["k8sSchema.pkl"] {
+    """
+    module dev.restate.k8sSchema
+    
+    /// Resource modules keyed by `kind` and `apiVersion`.
+    ///
+    /// Note: Declared template type is [unknown] instead of `K8sResource`
+    /// to delay loading a template until it is accessed.
+    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+      ["RestateCluster"] {
+        ["restate.dev/v1"] = import("v1/RestateCluster")
+      }
+    }
+    
+    """
+  }
+  ["v1/RestateCluster.pkl"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -98,7 +114,23 @@ examples {
     
     """
   }
-  ["dev/restate/v1/RestateCluster.pkl -- dependency notation for k8s"] {
+  ["k8sSchema.pkl -- dependency notation for k8s"] {
+    """
+    module dev.restate.k8sSchema
+    
+    /// Resource modules keyed by `kind` and `apiVersion`.
+    ///
+    /// Note: Declared template type is [unknown] instead of `K8sResource`
+    /// to delay loading a template until it is accessed.
+    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+      ["RestateCluster"] {
+        ["restate.dev/v1"] = import("v1/RestateCluster")
+      }
+    }
+    
+    """
+  }
+  ["v1/RestateCluster.pkl -- dependency notation for k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -197,7 +229,23 @@ examples {
     
     """
   }
-  ["dev/restate/v1/RestateCluster.pkl -- different version of k8s"] {
+  ["k8sSchema.pkl -- different version of k8s"] {
+    """
+    module dev.restate.k8sSchema
+    
+    /// Resource modules keyed by `kind` and `apiVersion`.
+    ///
+    /// Note: Declared template type is [unknown] instead of `K8sResource`
+    /// to delay loading a template until it is accessed.
+    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+      ["RestateCluster"] {
+        ["restate.dev/v1"] = import("v1/RestateCluster")
+      }
+    }
+    
+    """
+  }
+  ["v1/RestateCluster.pkl -- different version of k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
     ///
@@ -298,14 +346,28 @@ examples {
   }
   ["conflicting schemas"] {
     """
+    module com.bar.k8sSchema
+    
+    /// Resource modules keyed by `kind` and `apiVersion`.
+    ///
+    /// Note: Declared template type is [unknown] instead of `K8sResource`
+    /// to delay loading a template until it is accessed.
+    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+      ["FooBar"] {
+        ["bar.com/v1"] = import("v1/FooBar")
+      }
+    }
+    
+    """
+    """
     /// This module was generated from the CustomResourceDefinition at <dummy://test_uri>.
-    module bar.foo.v1.FooBar
+    module com.bar.v1.FooBar
     
     extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
     
     import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
     
-    fixed apiVersion: "foo.bar/v1"
+    fixed apiVersion: "bar.com/v1"
     
     fixed kind: "FooBar"
     
@@ -375,7 +437,8 @@ examples {
     """
   }
   ["apiGroup subdomains"] {
-    Pair("v1/Foo.pkl", "bar.v1.Foo")
-    Pair("baz/v1/Qux.pkl", "bar.baz.v1.Qux")
+    Pair("k8sSchema.pkl", "bar.k8sSchema")
+    Pair("com/bar/v1/Foo.pkl", "com.bar.v1.Foo")
+    Pair("com/bar/baz/v1/Qux.pkl", "com.bar.baz.v1.Qux")
   }
 }

--- a/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/ModuleGenerator.pkl-expected.pcf
@@ -1,20 +1,4 @@
 examples {
-  ["k8sSchema.pkl"] {
-    """
-    module dev.restate.k8sSchema
-    
-    /// Resource modules keyed by `kind` and `apiVersion`.
-    ///
-    /// Note: Declared template type is [unknown] instead of `K8sResource`
-    /// to delay loading a template until it is accessed.
-    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
-      ["RestateCluster"] {
-        ["restate.dev/v1"] = import("v1/RestateCluster")
-      }
-    }
-    
-    """
-  }
   ["v1/RestateCluster.pkl"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
@@ -114,22 +98,6 @@ examples {
     
     """
   }
-  ["k8sSchema.pkl -- dependency notation for k8s"] {
-    """
-    module dev.restate.k8sSchema
-    
-    /// Resource modules keyed by `kind` and `apiVersion`.
-    ///
-    /// Note: Declared template type is [unknown] instead of `K8sResource`
-    /// to delay loading a template until it is accessed.
-    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
-      ["RestateCluster"] {
-        ["restate.dev/v1"] = import("v1/RestateCluster")
-      }
-    }
-    
-    """
-  }
   ["v1/RestateCluster.pkl -- dependency notation for k8s"] {
     """
     /// Auto-generated derived type for RestateClusterSpec via `CustomResource`
@@ -225,22 +193,6 @@ examples {
       /// storageRequestBytes is the amount of storage to request in volume claims. It is allowed to increase
       /// but not decrease.
       storageRequestBytes: Int(this >= 1.0)
-    }
-    
-    """
-  }
-  ["k8sSchema.pkl -- different version of k8s"] {
-    """
-    module dev.restate.k8sSchema
-    
-    /// Resource modules keyed by `kind` and `apiVersion`.
-    ///
-    /// Note: Declared template type is [unknown] instead of `K8sResource`
-    /// to delay loading a template until it is accessed.
-    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
-      ["RestateCluster"] {
-        ["restate.dev/v1"] = import("v1/RestateCluster")
-      }
     }
     
     """
@@ -346,20 +298,6 @@ examples {
   }
   ["conflicting schemas"] {
     """
-    module com.bar.k8sSchema
-    
-    /// Resource modules keyed by `kind` and `apiVersion`.
-    ///
-    /// Note: Declared template type is [unknown] instead of `K8sResource`
-    /// to delay loading a template until it is accessed.
-    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
-      ["FooBar"] {
-        ["bar.com/v1"] = import("v1/FooBar")
-      }
-    }
-    
-    """
-    """
     /// This module was generated from the CustomResourceDefinition at <dummy://test_uri>.
     module com.bar.v1.FooBar
     
@@ -437,7 +375,6 @@ examples {
     """
   }
   ["apiGroup subdomains"] {
-    Pair("k8sSchema.pkl", "bar.k8sSchema")
     Pair("com/bar/v1/Foo.pkl", "com.bar.v1.Foo")
     Pair("com/bar/baz/v1/Qux.pkl", "com.bar.baz.v1.Qux")
   }

--- a/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl
+++ b/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+module k8s.contrib.crd.tests.SchemaGenerator
+
+amends "pkl:test"
+
+import "../generate.pkl"
+
+examples {
+  ["schema generation"] {
+    (generate) {
+      sourceContents = read("fixtures/crds_subdomain.yaml")
+      source = "dummy://test_uri"
+      baseApiGroup = "bar.com"
+    }.output.files["k8sSchema.pkl"].text
+  }
+}

--- a/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl
+++ b/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl
@@ -22,6 +22,7 @@ import "../generate.pkl"
 examples {
   ["schema generation"] {
     (generate) {
+      generateSchema = true
       sourceContents = read("fixtures/crds_subdomain.yaml")
       source = "dummy://test_uri"
       baseApiGroup = "bar.com"

--- a/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl-expected.pcf
@@ -3,11 +3,10 @@ examples {
     """
     module com.bar.k8sSchema
     
+    import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+    
     /// Resource modules keyed by `kind` and `apiVersion`.
-    ///
-    /// Note: Declared template type is [unknown] instead of `K8sResource`
-    /// to delay loading a template until it is accessed.
-    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+    resourceTemplates: Mapping<String, Mapping<String, K8sResource>> = new {
       ["Foo"] {
         ["bar.com/v1"] = import("v1/Foo")
       }

--- a/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl-expected.pcf
+++ b/packages/k8s.contrib.crd/tests/SchemaGenerator.pkl-expected.pcf
@@ -1,0 +1,21 @@
+examples {
+  ["schema generation"] {
+    """
+    module com.bar.k8sSchema
+    
+    /// Resource modules keyed by `kind` and `apiVersion`.
+    ///
+    /// Note: Declared template type is [unknown] instead of `K8sResource`
+    /// to delay loading a template until it is accessed.
+    resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
+      ["Foo"] {
+        ["bar.com/v1"] = import("v1/Foo")
+      }
+      ["Qux"] {
+        ["baz.bar.com/v1"] = import("baz/v1/Qux")
+      }
+    }
+    
+    """
+  }
+}

--- a/packages/k8s.contrib.crd/tests/fixtures/crds_conflict.yaml
+++ b/packages/k8s.contrib.crd/tests/fixtures/crds_conflict.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: foo.bar.com
 spec:
-  group: foo.bar
+  group: bar.com
   names:
     categories: []
     kind: FooBar

--- a/packages/k8s.contrib.crd/tests/fixtures/crds_subdomain.yaml
+++ b/packages/k8s.contrib.crd/tests/fixtures/crds_subdomain.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   name: foo.bar.com
 spec:
-  group: bar
+  group: bar.com
   names:
     categories: []
     kind: Foo
@@ -84,7 +84,7 @@ kind: CustomResourceDefinition
 metadata:
   name: qux.baz.bar.com
 spec:
-  group: baz.bar
+  group: baz.bar.com
   names:
     categories: []
     kind: Qux


### PR DESCRIPTION
This PR adds generation of a schema module similar to [the one from pkl-k8s](https://github.com/apple/pkl-k8s/blob/main/generated-package/k8sSchema.pkl), which enables easy import and use in [`k8s.contrib`'s converter module](https://pkl-lang.org/package-docs/pkg.pkl-lang.org/pkl-pantry/k8s.contrib/current/convert/index.html#resourcesToConvert)