### PR TITLE
[com.circleci.v2] Add support for `circleci_ip_ranges` option in a Job class

### DIFF
--- a/packages/com.circleci.v2/Config.pkl
+++ b/packages/com.circleci.v2/Config.pkl
@@ -186,6 +186,9 @@ class Job {
 
   /// Options for [machine executor](https://circleci.com/docs/configuration-reference/#machine)
   machine: Machine?
+
+  // Options for CircleCI [IP ranges feature](https://circleci.com/docs/guides/security/ip-ranges/).
+  circleci_ip_ranges: Boolean?
 }
 
 typealias ResourceClass =

--- a/packages/com.circleci.v2/PklProject
+++ b/packages/com.circleci.v2/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.5.0"
+  version = "1.6.0"
 }


### PR DESCRIPTION
`circleci_ip_ranges` is an option available for CircleCI's paid account in Performance or Scale plan.

refs:
* https://circleci.com/docs/reference/configuration-reference/#circleciipranges
* https://circleci.com/docs/guides/security/ip-ranges/