### PR TITLE
Add Cilium k8s CRDs

### DIFF
--- a/packages/io.cilium/PklProject
+++ b/packages/io.cilium/PklProject
@@ -1,0 +1,9 @@
+amends "../basePklProject.pkl"
+
+dependencies {
+  ["k8s"] { uri = "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.3.0" }
+}
+
+package {
+  version = "1.0.0"
+}

--- a/packages/io.cilium/PklProject
+++ b/packages/io.cilium/PklProject
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 amends "../basePklProject.pkl"
 
 dependencies {

--- a/packages/io.cilium/PklProject.deps.json
+++ b/packages/io.cilium/PklProject.deps.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "resolvedDependencies": {
+    "package://pkg.pkl-lang.org/pkl-k8s/k8s@1": {
+      "type": "remote",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-k8s/k8s@1.3.0",
+      "checksums": {
+        "sha256": "1d948c9fc41e188fcd18ebb656b5d9ddc5f377cb16158bb421be7752bb913926"
+      }
+    }
+  }
+}

--- a/packages/io.cilium/examples/allowAppToOtel.pkl
+++ b/packages/io.cilium/examples/allowAppToOtel.pkl
@@ -1,0 +1,36 @@
+amends "../v2/CiliumNetworkPolicy.pkl"
+
+metadata {
+  name = "allow-app-to-otel"
+  namespace = "observability"
+}
+
+spec {
+  endpointSelector {
+    matchLabels {
+      ["app"] = "otel-collector"
+    }
+  }
+  ingress {
+    new {
+      fromEndpoints {
+        new {
+          matchLabels {
+            ["app"] = "myapp"
+            ["io.kubernetes.pod.namespace"] = "testapp"
+          }
+        }
+      }
+    }
+    new {
+      toPorts {
+        new {
+          ports {
+            new { port = "4317"; protocol = "TCP" }
+            new { port = "4318"; protocol = "TCP" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/io.cilium/examples/allowAppToOtel.pkl
+++ b/packages/io.cilium/examples/allowAppToOtel.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 amends "../v2/CiliumNetworkPolicy.pkl"
 
 metadata {

--- a/packages/io.cilium/examples/defaultDenyPolicy.pkl
+++ b/packages/io.cilium/examples/defaultDenyPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 amends "../v2/CiliumNetworkPolicy.pkl"
 
 metadata {

--- a/packages/io.cilium/examples/defaultDenyPolicy.pkl
+++ b/packages/io.cilium/examples/defaultDenyPolicy.pkl
@@ -1,0 +1,48 @@
+amends "../v2/CiliumNetworkPolicy.pkl"
+
+metadata {
+  name = "default-deny"
+  namespace = "testapp"
+}
+
+spec {
+  endpointSelector {}
+  ingress {
+    new {
+      fromEndpoints {
+        new {
+          matchLabels {
+            ["io.kubernetes.pod.namespace"] = "kube-system"
+          }
+        }
+      }
+    }
+  }
+  egress {
+    new {
+      toEndpoints {
+        new {
+          matchLabels {
+            ["io.kubernetes.pod.namespace"] = "kube-system"
+          }
+        }
+      }
+    }
+    new {
+      toFQDNs {
+        new { matchName = "google.com" }
+        new { matchName = "www.google.com" }
+      }
+    }
+    new {
+      toPorts {
+        new {
+          ports {
+            new { port = "53"; protocol = "UDP" }
+            new { port = "53"; protocol = "TCP" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/io.cilium/generate.sh
+++ b/packages/io.cilium/generate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE_URL="https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds"
+GENERATE_PKG="package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@4.2.1#/generate.pkl"
+
+V2_CRDS=(
+  ciliumbgpadvertisements.yaml
+  ciliumbgpclusterconfigs.yaml
+  ciliumbgpnodeconfigoverrides.yaml
+  ciliumbgpnodeconfigs.yaml
+  ciliumbgppeerconfigs.yaml
+  ciliumcidrgroups.yaml
+  ciliumclusterwideenvoyconfigs.yaml
+  ciliumclusterwidenetworkpolicies.yaml
+  ciliumegressgatewaypolicies.yaml
+  ciliumendpoints.yaml
+  ciliumenvoyconfigs.yaml
+  ciliumidentities.yaml
+  ciliumloadbalancerippools.yaml
+  ciliumlocalredirectpolicies.yaml
+  ciliumnetworkpolicies.yaml
+  ciliumnodeconfigs.yaml
+  ciliumnodes.yaml
+)
+
+V2ALPHA1_CRDS=(
+  ciliumendpointslices.yaml
+  ciliumgatewayclassconfigs.yaml
+  ciliuml2announcementpolicies.yaml
+  ciliumpodippools.yaml
+)
+
+for crd in "${V2_CRDS[@]}"; do
+  echo "Generating v2/$crd..."
+  pkl eval "$GENERATE_PKG" -m . -p source="$BASE_URL/v2/$crd" -p baseApiGroup="cilium.io"
+done
+
+for crd in "${V2ALPHA1_CRDS[@]}"; do
+  echo "Generating v2alpha1/$crd..."
+  pkl eval "$GENERATE_PKG" -m . -p source="$BASE_URL/v2alpha1/$crd" -p baseApiGroup="cilium.io"
+done
+
+echo "Done!"

--- a/packages/io.cilium/tests/examples.pkl
+++ b/packages/io.cilium/tests/examples.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 module io.cilium.tests.examples
 
 amends "pkl:test"

--- a/packages/io.cilium/tests/examples.pkl
+++ b/packages/io.cilium/tests/examples.pkl
@@ -1,0 +1,13 @@
+module io.cilium.tests.examples
+
+amends "pkl:test"
+
+import* "../examples/*.pkl" as allExamples
+
+examples {
+  for (name in allExamples.keys) {
+    [name.replaceFirst("../examples/", "")] {
+      allExamples[name].output.text
+    }
+  }
+}

--- a/packages/io.cilium/tests/examples.pkl-expected.pcf
+++ b/packages/io.cilium/tests/examples.pkl-expected.pcf
@@ -1,0 +1,56 @@
+examples {
+  ["defaultDenyPolicy.pkl"] {
+    """
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: default-deny
+      namespace: testapp
+    spec:
+      egress:
+      - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+      - toFQDNs:
+        - matchName: google.com
+        - matchName: www.google.com
+      - toPorts:
+        - ports:
+          - port: '53'
+            protocol: UDP
+          - port: '53'
+            protocol: TCP
+      endpointSelector: {}
+      ingress:
+      - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+
+    """
+  }
+  ["allowAppToOtel.pkl"] {
+    """
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: allow-app-to-otel
+      namespace: observability
+    spec:
+      endpointSelector:
+        matchLabels:
+          app: otel-collector
+      ingress:
+      - fromEndpoints:
+        - matchLabels:
+            app: myapp
+            io.kubernetes.pod.namespace: testapp
+      - toPorts:
+        - ports:
+          - port: '4317'
+            protocol: TCP
+          - port: '4318'
+            protocol: TCP
+
+    """
+  }
+}

--- a/packages/io.cilium/v2/CiliumBGPAdvertisement.pkl
+++ b/packages/io.cilium/v2/CiliumBGPAdvertisement.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPAdvertisement is the Schema for the ciliumbgpadvertisements API
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2/CiliumBGPAdvertisement.pkl
+++ b/packages/io.cilium/v2/CiliumBGPAdvertisement.pkl
@@ -1,0 +1,136 @@
+/// CiliumBGPAdvertisement is the Schema for the ciliumbgpadvertisements API
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml>.
+module io.cilium.v2.CiliumBGPAdvertisement
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumBGPAdvertisement"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec
+
+class Spec {
+  /// Advertisements is a list of BGP advertisements.
+  advertisements: Listing<Advertisement>
+}
+
+/// BGPAdvertisement defines which routes Cilium should advertise to BGP peers. Optionally, additional
+/// attributes can be set to the advertised routes.
+class Advertisement {
+  /// AdvertisementType defines type of advertisement which has to be advertised.
+  advertisementType: "PodCIDR"|"CiliumPodIPPool"|"Service"|"Interface"
+
+  /// Attributes defines additional attributes to set to the advertised routes. If not specified, no
+  /// additional attributes are set.
+  attributes: Attributes?
+
+  /// Interface defines configuration options for the "Interface" advertisementType.
+  interface: Interface?
+
+  /// Selector is a label selector to select objects of the type specified by AdvertisementType. For the
+  /// PodCIDR AdvertisementType it is not applicable. For other advertisement types, if not specified, no
+  /// objects of the type specified by AdvertisementType are selected for advertisement.
+  selector: Selector?
+
+  /// Service defines configuration options for the "Service" advertisementType.
+  service: Service?
+}
+
+/// Attributes defines additional attributes to set to the advertised routes. If not specified, no
+/// additional attributes are set.
+class Attributes {
+  /// Communities sets the community attributes in the route. If not specified, no community attribute is
+  /// set.
+  communities: Communities?
+
+  /// LocalPreference sets the local preference attribute in the route. If not specified, no local
+  /// preference attribute is set.
+  localPreference: Int?
+}
+
+/// Communities sets the community attributes in the route. If not specified, no community attribute is
+/// set.
+class Communities {
+  /// Large holds a list of the BGP Large Communities Attribute (RFC 8092) values.
+  large: Listing<String(matches(Regex("^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$")))>?
+
+  /// Standard holds a list of "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as
+  /// numeric values.
+  standard: Listing<String(matches(Regex("^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$|^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")))>?
+
+  /// WellKnown holds a list "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as
+  /// well-known string aliases to their numeric values.
+  wellKnown: Listing<
+    "internet"
+    |"planned-shut"
+    |"accept-own"
+    |"route-filter-translated-v4"
+    |"route-filter-v4"
+    |"route-filter-translated-v6"
+    |"route-filter-v6"
+    |"llgr-stale"
+    |"no-llgr"
+    |"blackhole"
+    |"no-export"
+    |"no-advertise"
+    |"no-export-subconfed"
+    |"no-peer">?
+}
+
+/// Interface defines configuration options for the "Interface" advertisementType.
+class Interface {
+  /// Name of local interface of whose IP addresses will be advertised via BGP. Each IP address applied
+  /// on the interface is advertised as a /32 prefix (for IPv4) or a /128 prefix (for IPv6).
+  name: String
+}
+
+/// Selector is a label selector to select objects of the type specified by AdvertisementType. For the
+/// PodCIDR AdvertisementType it is not applicable. For other advertisement types, if not specified, no
+/// objects of the type specified by AdvertisementType are selected for advertisement.
+class Selector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Service defines configuration options for the "Service" advertisementType.
+class Service {
+  /// Addresses is a list of service address types which needs to be advertised via BGP.
+  addresses: Listing<"LoadBalancerIP"|"ClusterIP"|"ExternalIP">(!isEmpty)
+
+  /// IPv4 mask to aggregate BGP route advertisements of service
+  aggregationLengthIPv4: Int(isBetween(0, 31))?
+
+  /// IPv6 mask to aggregate BGP route advertisements of service
+  aggregationLengthIPv6: Int(isBetween(0, 127))?
+}

--- a/packages/io.cilium/v2/CiliumBGPClusterConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPClusterConfig.pkl
@@ -1,0 +1,161 @@
+/// CiliumBGPClusterConfig is the Schema for the CiliumBGPClusterConfig API
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml>.
+module io.cilium.v2.CiliumBGPClusterConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumBGPClusterConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec defines the desired cluster configuration of the BGP control plane.
+spec: Spec
+
+/// Status is a running status of the cluster configuration
+status: Status?
+
+/// Spec defines the desired cluster configuration of the BGP control plane.
+class Spec {
+  /// A list of CiliumBGPInstance(s) which instructs the BGP control plane how to instantiate virtual BGP
+  /// routers.
+  bgpInstances: Listing<BgpInstance>(length.isBetween(1, 16))
+
+  /// NodeSelector selects a group of nodes where this BGP Cluster config applies. If empty / nil this
+  /// config applies to all nodes.
+  nodeSelector: NodeSelector?
+}
+
+class BgpInstance {
+  /// LocalASN is the ASN of this BGP instance. Supports extended 32bit ASNs.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is the port on which the BGP daemon listens for incoming connections.
+  ///
+  /// If not specified, BGP instance will not listen for incoming connections.
+  localPort: Int(isBetween(1, 65535))?
+
+  /// Name is the name of the BGP instance. It is a unique identifier for the BGP instance within the
+  /// cluster configuration.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of neighboring BGP peers for this virtual router
+  peers: Listing<Peer>?
+}
+
+class Peer {
+  /// AutoDiscovery is the configuration for auto-discovery of the peer address.
+  autoDiscovery: AutoDiscovery?
+
+  /// Name is the name of the BGP peer. It is a unique identifier for the peer within the BGP instance.
+  name: String(length.isBetween(1, 255))
+
+  /// PeerASN is the ASN of the peer BGP router. Supports extended 32bit ASNs.
+  ///
+  /// If peerASN is 0, the BGP OPEN message validation of ASN will be disabled and ASN will be determined
+  /// based on peer's OPEN message.
+  ///
+  /// Default if undefined: `0`
+  peerASN: UInt32?
+
+  /// PeerAddress is the IP address of the neighbor. Supports IPv4 and IPv6 addresses.
+  peerAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+  /// configuration is used for this peer.
+  peerConfigRef: PeerConfigRef?
+}
+
+/// AutoDiscovery is the configuration for auto-discovery of the peer address.
+class AutoDiscovery {
+  /// defaultGateway is the configuration for auto-discovery of the default gateway.
+  defaultGateway: DefaultGateway?
+
+  /// mode is the mode of the auto-discovery.
+  mode: "DefaultGateway"
+}
+
+/// defaultGateway is the configuration for auto-discovery of the default gateway.
+class DefaultGateway {
+  /// addressFamily is the address family of the default gateway.
+  addressFamily: "ipv4"|"ipv6"
+}
+
+/// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+/// configuration is used for this peer.
+class PeerConfigRef {
+  /// Name is the name of the peer config resource. Name refers to the name of a Kubernetes object
+  /// (typically a CiliumBGPPeerConfig).
+  name: String
+}
+
+/// NodeSelector selects a group of nodes where this BGP Cluster config applies. If empty / nil this
+/// config applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Status is a running status of the cluster configuration
+class Status {
+  /// The current conditions of the CiliumBGPClusterConfig
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2/CiliumBGPClusterConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPClusterConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPClusterConfig is the Schema for the CiliumBGPClusterConfig API
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2/CiliumBGPNodeConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPNodeConfig.pkl
@@ -1,0 +1,212 @@
+/// CiliumBGPNodeConfig is node local configuration for BGP agent. Name of the object should be node
+/// name. This resource will be created by Cilium operator and is read-only for the users.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml>.
+module io.cilium.v2.CiliumBGPNodeConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumBGPNodeConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+spec: Spec
+
+/// Status is the most recently observed status of the CiliumBGPNodeConfig.
+status: Status?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+class Spec {
+  /// BGPInstances is a list of BGP router instances on the node.
+  bgpInstances: Listing<BgpInstance>(length.isBetween(1, 16))
+}
+
+/// CiliumBGPNodeInstance is a single BGP router instance configuration on the node.
+class BgpInstance {
+  /// LocalASN is the ASN of this virtual router. Supports extended 32bit ASNs.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is the port on which the BGP daemon listens for incoming connections.
+  ///
+  /// If not specified, BGP instance will not listen for incoming connections.
+  localPort: Int(isBetween(1, 65535))?
+
+  /// Name is the name of the BGP instance. This name is used to identify the BGP instance on the node.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of neighboring BGP peers for this virtual router
+  peers: Listing<Peer>?
+
+  /// RouterID is the BGP router ID of this virtual router. This configuration is derived from
+  /// CiliumBGPNodeConfigOverride resource.
+  ///
+  /// If not specified, the router ID will be derived from the node local address.
+  routerID: String?
+}
+
+class Peer {
+  /// AutoDiscovery is the configuration for auto-discovery of the peer address.
+  autoDiscovery: AutoDiscovery?
+
+  /// LocalAddress is the IP address of the local interface to use for the peering session. This
+  /// configuration is derived from CiliumBGPNodeConfigOverride resource. If not specified, the local
+  /// address will be used for setting up peering.
+  localAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// Name is the name of the BGP peer. This name is used to identify the BGP peer for the BGP instance.
+  name: String
+
+  /// PeerASN is the ASN of the peer BGP router. Supports extended 32bit ASNs
+  peerASN: UInt32?
+
+  /// PeerAddress is the IP address of the neighbor. Supports IPv4 and IPv6 addresses.
+  peerAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+  /// configuration is used for this peer.
+  peerConfigRef: PeerConfigRef?
+}
+
+/// AutoDiscovery is the configuration for auto-discovery of the peer address.
+class AutoDiscovery {
+  /// defaultGateway is the configuration for auto-discovery of the default gateway.
+  defaultGateway: DefaultGateway?
+
+  /// mode is the mode of the auto-discovery.
+  mode: "DefaultGateway"
+}
+
+/// defaultGateway is the configuration for auto-discovery of the default gateway.
+class DefaultGateway {
+  /// addressFamily is the address family of the default gateway.
+  addressFamily: "ipv4"|"ipv6"
+}
+
+/// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+/// configuration is used for this peer.
+class PeerConfigRef {
+  /// Name is the name of the peer config resource. Name refers to the name of a Kubernetes object
+  /// (typically a CiliumBGPPeerConfig).
+  name: String
+}
+
+/// Status is the most recently observed status of the CiliumBGPNodeConfig.
+class Status {
+  /// BGPInstances is the status of the BGP instances on the node.
+  bgpInstances: Listing<StatusBgpInstance>?
+
+  /// The current conditions of the CiliumBGPNodeConfig
+  conditions: Listing<Condition>?
+}
+
+class StatusBgpInstance {
+  /// LocalASN is the ASN of this BGP instance.
+  localASN: Int?
+
+  /// Name is the name of the BGP instance. This name is used to identify the BGP instance on the node.
+  name: String
+
+  /// PeerStatuses is the state of the BGP peers for this BGP instance.
+  peers: Listing<BgpInstancePeer>?
+}
+
+/// CiliumBGPNodePeerStatus is the status of a BGP peer.
+class BgpInstancePeer {
+  /// EstablishedTime is the time when the peering session was established. It is represented in RFC3339
+  /// form and is in UTC.
+  establishedTime: String?
+
+  /// Name is the name of the BGP peer.
+  name: String
+
+  /// PeerASN is the ASN of the neighbor.
+  peerASN: Int?
+
+  /// PeerAddress is the IP address of the neighbor.
+  peerAddress: String
+
+  /// PeeringState is last known state of the peering session.
+  peeringState: String?
+
+  /// RouteCount is the number of routes exchanged with this peer per AFI/SAFI.
+  routeCount: Listing<RouteCount>?
+
+  /// Timers is the state of the negotiated BGP timers for this peer.
+  timers: Timers?
+}
+
+class RouteCount {
+  /// Advertised is the number of routes advertised to this peer.
+  advertised: Int?
+
+  /// Afi is the Address Family Identifier (AFI) of the family.
+  afi: "ipv4"|"ipv6"|"l2vpn"|"ls"|"opaque"
+
+  /// Received is the number of routes received from this peer.
+  received: Int?
+
+  /// Safi is the Subsequent Address Family Identifier (SAFI) of the family.
+  safi: 
+    "unicast"
+    |"multicast"
+    |"mpls_label"
+    |"encapsulation"
+    |"vpls"
+    |"evpn"
+    |"ls"
+    |"sr_policy"
+    |"mup"
+    |"mpls_vpn"
+    |"mpls_vpn_multicast"
+    |"route_target_constraints"
+    |"flowspec_unicast"
+    |"flowspec_vpn"
+    |"key_value"
+}
+
+/// Timers is the state of the negotiated BGP timers for this peer.
+class Timers {
+  /// AppliedHoldTimeSeconds is the negotiated hold time for this peer.
+  appliedHoldTimeSeconds: Int?
+
+  /// AppliedKeepaliveSeconds is the negotiated keepalive time for this peer.
+  appliedKeepaliveSeconds: Int?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2/CiliumBGPNodeConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPNodeConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPNodeConfig is node local configuration for BGP agent. Name of the object should be node
 /// name. This resource will be created by Cilium operator and is read-only for the users.
 ///

--- a/packages/io.cilium/v2/CiliumBGPNodeConfigOverride.pkl
+++ b/packages/io.cilium/v2/CiliumBGPNodeConfigOverride.pkl
@@ -1,0 +1,62 @@
+/// CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig. It allows
+/// fine-tuning of BGP behavior on a per-node basis. For the override to be effective, the names in
+/// CiliumBGPNodeConfigOverride and CiliumBGPNodeConfig must match exactly. This matching ensures that
+/// specific node configurations are applied correctly and only where intended.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigoverrides.yaml>.
+module io.cilium.v2.CiliumBGPNodeConfigOverride
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumBGPNodeConfigOverride"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+spec: Spec
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+class Spec {
+  /// BGPInstances is a list of BGP instances to override.
+  bgpInstances: Listing<BgpInstance>(!isEmpty)
+}
+
+/// CiliumBGPNodeConfigInstanceOverride defines configuration options which can be overridden for a
+/// specific BGP instance.
+class BgpInstance {
+  /// LocalASN is the ASN to use for this BGP instance.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is port to use for this BGP instance.
+  localPort: Int?
+
+  /// Name is the name of the BGP instance for which the configuration is overridden.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of peer configurations to override.
+  peers: Listing<Peer>?
+
+  /// RouterID is BGP router id to use for this instance. It must be unique across all BGP instances.
+  routerID: String?
+}
+
+/// CiliumBGPNodeConfigPeerOverride defines configuration options which can be overridden for a specific
+/// peer.
+class Peer {
+  /// LocalAddress is the IP address to use for connecting to this peer.
+  localAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// LocalPort is source port to use for connecting to this peer.
+  localPort: Int?
+
+  /// Name is the name of the peer for which the configuration is overridden.
+  name: String(length.isBetween(1, 255))
+}

--- a/packages/io.cilium/v2/CiliumBGPNodeConfigOverride.pkl
+++ b/packages/io.cilium/v2/CiliumBGPNodeConfigOverride.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig. It allows
 /// fine-tuning of BGP behavior on a per-node basis. For the override to be effective, the names in
 /// CiliumBGPNodeConfigOverride and CiliumBGPNodeConfig must match exactly. This matching ensures that

--- a/packages/io.cilium/v2/CiliumBGPPeerConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPPeerConfig.pkl
@@ -1,0 +1,217 @@
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml>.
+module io.cilium.v2.CiliumBGPPeerConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumBGPPeerConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+spec: Spec
+
+/// Status is the running status of the CiliumBGPPeerConfig
+status: Status?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+class Spec {
+  /// AuthSecretRef is the name of the secret to use to fetch a TCP authentication password for this
+  /// peer.
+  ///
+  /// If not specified, no authentication is used.
+  authSecretRef: String?
+
+  /// EBGPMultihopTTL controls the multi-hop feature for eBGP peers. Its value defines the Time To Live
+  /// (TTL) value used in BGP packets sent to the peer.
+  ///
+  /// If not specified, EBGP multihop is disabled. This field is ignored for iBGP neighbors.
+  ///
+  /// Default if undefined: `1`
+  ebgpMultihop: Int(isBetween(1, 255))?
+
+  /// Families, if provided, defines a set of AFI/SAFIs the speaker will negotiate with it's peer.
+  ///
+  /// If not specified, the default families of IPv6/unicast and IPv4/unicast will be created.
+  families: Listing<Family>?
+
+  /// GracefulRestart defines graceful restart parameters which are negotiated with this peer.
+  ///
+  /// If not specified, the graceful restart capability is disabled.
+  gracefulRestart: GracefulRestart?
+
+  /// Timers defines the BGP timers for the peer.
+  ///
+  /// If not specified, the default timers are used.
+  timers: Timers?
+
+  /// Transport defines the BGP transport parameters for the peer.
+  ///
+  /// If not specified, the default transport parameters are used.
+  transport: Transport?
+}
+
+/// CiliumBGPFamilyWithAdverts represents a AFI/SAFI address family pair along with reference to BGP
+/// Advertisements.
+class Family {
+  /// Advertisements selects group of BGP Advertisement(s) to advertise for this family.
+  ///
+  /// If not specified, no advertisements are sent for this family.
+  advertisements: Advertisements?
+
+  /// Afi is the Address Family Identifier (AFI) of the family.
+  afi: "ipv4"|"ipv6"|"l2vpn"|"ls"|"opaque"
+
+  /// Safi is the Subsequent Address Family Identifier (SAFI) of the family.
+  safi: 
+    "unicast"
+    |"multicast"
+    |"mpls_label"
+    |"encapsulation"
+    |"vpls"
+    |"evpn"
+    |"ls"
+    |"sr_policy"
+    |"mup"
+    |"mpls_vpn"
+    |"mpls_vpn_multicast"
+    |"route_target_constraints"
+    |"flowspec_unicast"
+    |"flowspec_vpn"
+    |"key_value"
+}
+
+/// Advertisements selects group of BGP Advertisement(s) to advertise for this family.
+///
+/// If not specified, no advertisements are sent for this family.
+class Advertisements {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// GracefulRestart defines graceful restart parameters which are negotiated with this peer.
+///
+/// If not specified, the graceful restart capability is disabled.
+class GracefulRestart {
+  /// Enabled flag, when set enables graceful restart capability.
+  enabled: Boolean
+
+  /// RestartTimeSeconds is the estimated time it will take for the BGP session to be re-established with
+  /// peer after a restart. After this period, peer will remove stale routes. This is described RFC 4724
+  /// section 4.2.
+  ///
+  /// Default if undefined: `120`
+  restartTimeSeconds: Int(isBetween(1, 4095))?
+}
+
+/// Timers defines the BGP timers for the peer.
+///
+/// If not specified, the default timers are used.
+class Timers {
+  /// ConnectRetryTimeSeconds defines the initial value for the BGP ConnectRetryTimer (RFC 4271, Section
+  /// 8).
+  ///
+  /// If not specified, defaults to 120 seconds.
+  ///
+  /// Default if undefined: `120`
+  connectRetryTimeSeconds: Int(isBetween(1, 2147483647))?
+
+  /// HoldTimeSeconds defines the initial value for the BGP HoldTimer (RFC 4271, Section 4.2). Updating
+  /// this value will cause a session reset.
+  ///
+  /// If not specified, defaults to 90 seconds.
+  ///
+  /// Default if undefined: `90`
+  holdTimeSeconds: Int(isBetween(3, 65535))?
+
+  /// KeepaliveTimeSeconds defines the initial value for the BGP KeepaliveTimer (RFC 4271, Section 8). It
+  /// can not be larger than HoldTimeSeconds. Updating this value will cause a session reset.
+  ///
+  /// If not specified, defaults to 30 seconds.
+  ///
+  /// Default if undefined: `30`
+  keepAliveTimeSeconds: Int(isBetween(1, 65535))?
+}
+
+/// Transport defines the BGP transport parameters for the peer.
+///
+/// If not specified, the default transport parameters are used.
+class Transport {
+  /// PeerPort is the peer port to be used for the BGP session.
+  ///
+  /// If not specified, defaults to TCP port 179.
+  ///
+  /// Default if undefined: `179`
+  peerPort: Int(isBetween(1, 65535))?
+
+  /// SourceInterface is the name of a local interface, which IP address will be used as the source IP
+  /// address for the BGP session. The interface must not have more than one non-loopback, non-multicast
+  /// and non-link-local-IPv6 address per address family.
+  ///
+  /// If not specified, or if the provided interface is not found or missing a usable IP address, the
+  /// source IP address will be auto-detected based on the egress interface.
+  sourceInterface: String?
+}
+
+/// Status is the running status of the CiliumBGPPeerConfig
+class Status {
+  /// The current conditions of the CiliumBGPPeerConfig
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2/CiliumBGPPeerConfig.pkl
+++ b/packages/io.cilium/v2/CiliumBGPPeerConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// This module was generated from the CustomResourceDefinition at
 /// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml>.
 module io.cilium.v2.CiliumBGPPeerConfig

--- a/packages/io.cilium/v2/CiliumCIDRGroup.pkl
+++ b/packages/io.cilium/v2/CiliumCIDRGroup.pkl
@@ -1,0 +1,26 @@
+/// CiliumCIDRGroup is a list of external CIDRs (i.e: CIDRs selecting peers outside the clusters) that
+/// can be referenced as a single entity from CiliumNetworkPolicies.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumcidrgroups.yaml>.
+module io.cilium.v2.CiliumCIDRGroup
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumCIDRGroup"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec
+
+class Spec {
+  /// ExternalCIDRs is a list of CIDRs selecting peers outside the clusters.
+  externalCIDRs: Listing<String>(length >= 0)
+}

--- a/packages/io.cilium/v2/CiliumCIDRGroup.pkl
+++ b/packages/io.cilium/v2/CiliumCIDRGroup.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumCIDRGroup is a list of external CIDRs (i.e: CIDRs selecting peers outside the clusters) that
 /// can be referenced as a single entity from CiliumNetworkPolicies.
 ///

--- a/packages/io.cilium/v2/CiliumClusterwideEnvoyConfig.pkl
+++ b/packages/io.cilium/v2/CiliumClusterwideEnvoyConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// This module was generated from the CustomResourceDefinition at
 /// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwideenvoyconfigs.yaml>.
 module io.cilium.v2.CiliumClusterwideEnvoyConfig

--- a/packages/io.cilium/v2/CiliumClusterwideEnvoyConfig.pkl
+++ b/packages/io.cilium/v2/CiliumClusterwideEnvoyConfig.pkl
@@ -1,0 +1,102 @@
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwideenvoyconfigs.yaml>.
+module io.cilium.v2.CiliumClusterwideEnvoyConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumClusterwideEnvoyConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec?
+
+class Spec {
+  /// BackendServices specifies Kubernetes services whose backends are automatically synced to Envoy
+  /// using EDS. Traffic for these services is not forwarded to an Envoy listener. This allows an Envoy
+  /// listener load balance traffic to these backends while normal Cilium service load balancing takes
+  /// care of balancing traffic for these services at the same time.
+  backendServices: Listing<BackendService>?
+
+  /// NodeSelector is a label selector that determines to which nodes this configuration applies. If nil,
+  /// then this config applies to all nodes.
+  nodeSelector: NodeSelector?
+
+  /// Envoy xDS resources, a list of the following Envoy resource types:
+  /// type.googleapis.com/envoy.config.listener.v3.Listener,
+  /// type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
+  /// type.googleapis.com/envoy.config.cluster.v3.Cluster,
+  /// type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment, and
+  /// type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.
+  resources: Listing<Dynamic>
+
+  /// Services specifies Kubernetes services for which traffic is forwarded to an Envoy listener for L7
+  /// load balancing. Backends of these services are automatically synced to Envoy usign EDS.
+  services: Listing<Service>?
+}
+
+class BackendService {
+  /// Name is the name of a destination Kubernetes service that identifies traffic to be redirected.
+  name: String
+
+  /// Namespace is the Kubernetes service namespace. In CiliumEnvoyConfig namespace defaults to the
+  /// namespace of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults to "default".
+  namespace: String?
+
+  /// Ports is a set of port numbers, which can be used for filtering in case of underlying is exposing
+  /// multiple port numbers.
+  number: Listing<String>?
+}
+
+/// NodeSelector is a label selector that determines to which nodes this configuration applies. If nil,
+/// then this config applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+class Service {
+  /// Listener specifies the name of the Envoy listener the service traffic is redirected to. The
+  /// listener must be specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
+  ///
+  /// If omitted, the first listener specified in 'resources' is used.
+  listener: String?
+
+  /// Name is the name of a destination Kubernetes service that identifies traffic to be redirected.
+  name: String
+
+  /// Namespace is the Kubernetes service namespace. In CiliumEnvoyConfig namespace this is overridden to
+  /// the namespace of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults to "default".
+  namespace: String?
+
+  /// Ports is a set of service's frontend ports that should be redirected to the Envoy listener. By
+  /// default all frontend ports of the service are redirected.
+  ports: Listing<Int>?
+}

--- a/packages/io.cilium/v2/CiliumClusterwideNetworkPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumClusterwideNetworkPolicy.pkl
@@ -1,0 +1,1136 @@
+/// CiliumClusterwideNetworkPolicy is a Kubernetes third-party resource with an modified version of
+/// CiliumNetworkPolicy which is cluster scoped rather than namespace scoped.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml>.
+module io.cilium.v2.CiliumClusterwideNetworkPolicy
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumClusterwideNetworkPolicy"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the desired Cilium specific rule specification.
+spec: Spec?
+
+/// Specs is a list of desired Cilium specific rule specification.
+specs: Listing<ItemSpec>?
+
+/// Status is the status of the Cilium policy rule.
+///
+/// The reason this field exists in this structure is due a bug in the k8s code-generator that doesn't
+/// create a `UpdateStatus` method because the field does not exist in the structure.
+status: Status?
+
+/// Spec is the desired Cilium specific rule specification.
+class Spec {
+  /// Description is a free form string, it can be used by the creator of the rule to store human
+  /// readable explanation of the purpose of this rule. Rules cannot be identified by comment.
+  description: String?
+
+  /// Egress is a list of EgressRule which are enforced at egress. If omitted or empty, this rule does
+  /// not apply at egress.
+  egress: Listing<SpecEgres>?
+
+  /// EgressDeny is a list of EgressDenyRule which are enforced at egress. Any rule inserted here will be
+  /// denied regardless of the allowed egress rules in the 'egress' field. If omitted or empty, this rule
+  /// does not apply at egress.
+  egressDeny: Listing<SpecEgressDeny>?
+
+  /// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a
+  /// default deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy
+  /// to be dropped.
+  ///
+  /// If not specified, the default is true for each traffic direction that has rules, and false
+  /// otherwise. For example, if a policy only has Ingress or IngressDeny rules, then the default for
+  /// ingress is true and egress is false.
+  ///
+  /// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any
+  /// policy requests it.
+  ///
+  /// This is useful for creating broad-based network policies that will not cause endpoints to enter
+  /// default-deny mode.
+  enableDefaultDeny: SpecEnableDefaultDeny?
+
+  /// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive.
+  endpointSelector: SpecEndpointSelector?
+
+  /// Ingress is a list of IngressRule which are enforced at ingress. If omitted or empty, this rule does
+  /// not apply at ingress.
+  ingress: Listing<SpecIngres>?
+
+  /// IngressDeny is a list of IngressDenyRule which are enforced at ingress. Any rule inserted here will
+  /// be denied regardless of the allowed ingress rules in the 'ingress' field. If omitted or empty, this
+  /// rule does not apply at ingress.
+  ingressDeny: Listing<SpecIngressDeny>?
+
+  /// Labels is a list of optional strings which can be used to re-identify the rule or to store
+  /// metadata. It is possible to lookup or delete strings based on labels. Labels are not required to be
+  /// unique, multiple rules can have overlapping or identical labels.
+  labels: Listing<SpecLabel>?
+
+  /// Log specifies custom policy-specific Hubble logging configuration.
+  log: SpecLog?
+
+  /// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+  /// CiliumClusterwideNetworkPolicies.
+  nodeSelector: SpecNodeSelector?
+}
+
+/// EgressRule contains all rule types which can be applied at egress, i.e. network traffic that
+/// originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members of the structure are specified, then all members must match in order for the
+/// rule to take effect.
+///
+/// - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are mutually exclusive. Only
+/// one of these members may be present within an individual rule.
+class SpecEgres {
+  /// Authentication is the required authentication type for the allowed traffic, if any.
+  authentication: IngresAuthentication?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" is allowed to initiate type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections. Only connections destined for outside of the cluster and not targeting the host will
+  /// be subject to CIDR rules. This will match on the destination IP address of outgoing connections.
+  /// Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are
+  /// allowed between ToCIDR and ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24
+  toCIDR: Listing<String>?
+
+  /// ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections to in addition to connections which are allowed via ToEndpoints, along with a list of
+  /// subnets contained within their corresponding IP block to which traffic should not be allowed. This
+  /// will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or
+  /// into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+  /// ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+  toCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoints subject
+  /// to the rule are allowed to communicate.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" can communicate with any endpoint carrying the
+  /// label "role=backend".
+  ///
+  /// Note that while an empty non-nil ToEndpoints does not select anything, nil ToEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  toEndpoints: Listing<FromNode>?
+
+  /// ToEntities is a list of special entities to which the endpoint subject to the rule is allowed to
+  /// initiate connections. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  toEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// ToFQDN allows whitelisting DNS names in place of IPs. The IPs that result from DNS resolution of
+  /// `ToFQDN.MatchName`s are added to the same EgressRule object as ToCIDRSet entries, and behave
+  /// accordingly. Any L4 and L7 rules within this EgressRule will also apply to these IPs. The DNS -> IP
+  /// mapping is re-resolved periodically from within the cilium-agent, and the IPs in the DNS response
+  /// are effected in the policy for selected pods as-is (i.e. the list of IPs is not modified in any
+  /// way). Note: An explicit rule to allow for DNS traffic is needed for the pods, as ToFQDN counts as
+  /// an egress rule and will enforce egress policy when PolicyEnforcment=default. Note: If the resolved
+  /// IPs are IPs within the kubernetes cluster, the ToFQDN rule will not apply to that IP. Note: ToFQDN
+  /// cannot occur in the same policy as other To* rules.
+  toFQDNs: Listing<EgresToFQDN>?
+
+  /// ToGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: toGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  toGroups: Listing<IngressDenyFromGroup>?
+
+  /// ToNodes is a list of nodes identified by an EndpointSelector to which endpoints subject to the rule
+  /// is allowed to communicate.
+  toNodes: Listing<FromNode>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to
+  /// destination port 8080/tcp
+  toPorts: Listing<ToPort>?
+
+  /// Deprecated.
+  toRequires: Listing<String>(isEmpty)?
+
+  /// ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate
+  /// connections. Currently Cilium only supports toServices for K8s services.
+  toServices: Listing<EgressDenyToService>?
+}
+
+/// Authentication is the required authentication type for the allowed traffic, if any.
+class IngresAuthentication {
+  /// Mode is the required authentication mode for the allowed traffic, if any.
+  mode: "disabled"|"required"|"test-always-fail"
+}
+
+/// ICMPRule is a list of ICMP fields.
+class IngressDenyIcmp {
+  /// Fields is a list of ICMP fields.
+  fields: Listing<IcmpField>(length <= 40)?
+}
+
+/// ICMPField is a ICMP field.
+class IcmpField {
+  /// Family is a IP address version. Currently, we support `IPv4` and `IPv6`. `IPv4` is set as default.
+  ///
+  /// Default if undefined: `"IPv4"`
+  family: ("IPv4"|"IPv6")?
+
+  /// Type is a ICMP-type. It should be an 8bit code (0-255), or it's CamelCase name (for example,
+  /// "EchoReply"). Allowed ICMP types are: Ipv4: EchoReply | DestinationUnreachable | Redirect | Echo |
+  /// EchoRequest | RouterAdvertisement | RouterSelection | TimeExceeded | ParameterProblem | Timestamp |
+  /// TimestampReply | Photuris | ExtendedEcho Request | ExtendedEcho Reply Ipv6: DestinationUnreachable
+  /// | PacketTooBig | TimeExceeded | ParameterProblem | EchoRequest | EchoReply |
+  /// MulticastListenerQuery| MulticastListenerReport | MulticastListenerDone | RouterSolicitation |
+  /// RouterAdvertisement | NeighborSolicitation | NeighborAdvertisement | RedirectMessage |
+  /// RouterRenumbering | ICMPNodeInformationQuery | ICMPNodeInformationResponse |
+  /// InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement |
+  /// HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply | MobilePrefixSolicitation |
+  /// MobilePrefixAdvertisement | DuplicateAddressRequestCodeSuffix |
+  /// DuplicateAddressConfirmationCodeSuffix | ExtendedEchoRequest | ExtendedEchoReply
+  type: Int|String
+}
+
+/// CIDRRule is a rule that specifies a CIDR prefix to/from which outside communication is allowed, along
+/// with an optional list of subnets within that CIDR prefix to/from which outside communication is not
+/// allowed.
+class IngressDenyFromCIDRSet {
+  /// CIDR is a CIDR prefix / IP Block.
+  cidr: String?
+
+  /// CIDRGroupRef is a reference to a CiliumCIDRGroup object. A CiliumCIDRGroup contains a list of CIDRs
+  /// that the endpoint, subject to the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny)
+  /// receive connections from.
+  cidrGroupRef: String(length <= 253, matches(Regex(#"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"#)))?
+
+  /// CIDRGroupSelector selects CiliumCIDRGroups by their labels, rather than by name.
+  cidrGroupSelector: FromCIDRSetCidrGroupSelector?
+
+  /// ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule is not allowed to
+  /// initiate connections to. These CIDR prefixes should be contained within Cidr, using ExceptCIDRs
+  /// together with CIDRGroupRef is not supported yet. These exceptions are only applied to the Cidr in
+  /// this CIDRRule, and do not apply to any other CIDR prefixes in any other CIDRRules.
+  except: Listing<String>?
+}
+
+/// CIDRGroupSelector selects CiliumCIDRGroups by their labels, rather than by name.
+class FromCIDRSetCidrGroupSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class NodeSelectorMatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+class `FromCIDRSet[]Alternate0` {
+  cidr: Null
+}
+
+class `FromCIDRSet[]Alternate1` {
+  cidrGroupRef: Null
+}
+
+class `FromCIDRSet[]Alternate2` {
+  cidrGroupSelector: Null
+}
+
+/// EndpointSelector is a wrapper for k8s LabelSelector.
+class FromNode {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+class EgresToFQDN {
+  /// MatchName matches literal DNS names. A trailing "." is automatically added when missing.
+  matchName: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_]+[.]?)+$")))?
+
+  /// MatchPattern allows using wildcards to match DNS names. All wildcards are case insensitive. The
+  /// wildcards are: - "*" matches 0 or more DNS valid characters, and may occur anywhere in the pattern.
+  /// As a special case a "*" as the leftmost character, without a following "." matches all subdomains
+  /// as well as the name to the right. A trailing "." is automatically added when missing. - "**." is a
+  /// special prefix which matches all multilevel subdomains in the prefix.
+  ///
+  /// Examples: 1. `*.cilium.io` matches subdomains of cilium at that level www.cilium.io and
+  /// blog.cilium.io match, cilium.io and google.com do not 2. `*cilium.io` matches cilium.io and all
+  /// subdomains ends with "cilium.io" except those containing "." separator, subcilium.io and
+  /// sub-cilium.io match, www.cilium.io and blog.cilium.io does not 3. `sub*.cilium.io` matches
+  /// subdomains of cilium where the subdomain component begins with "sub". sub.cilium.io and
+  /// subdomain.cilium.io match while www.cilium.io, blog.cilium.io, cilium.io and google.com do not 4.
+  /// `**.cilium.io` matches all multilevel subdomains of cilium.io. "app.cilium.io" and
+  /// "test.app.cilium.io" match but not "cilium.io"
+  matchPattern: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))?
+}
+
+class `RulesDn[]Alternate0` {
+  matchName: Null
+}
+
+class `RulesDn[]Alternate1` {
+  matchPattern: Null
+}
+
+/// Groups structure to store all kinds of new integrations that needs a new derivative policy.
+class IngressDenyFromGroup {
+  /// AWSGroup is an structure that can be used to whitelisting information from AWS integration
+  aws: FromGroupAws?
+}
+
+/// AWSGroup is an structure that can be used to whitelisting information from AWS integration
+class FromGroupAws {
+  labels: Mapping<String, String>?
+
+  region: String?
+
+  securityGroupsIds: Listing<String>?
+
+  securityGroupsNames: Listing<String>?
+}
+
+/// PortRule is a list of ports/protocol combinations with optional Layer 7 rules which must be met.
+class ToPort {
+  /// listener specifies the name of a custom Envoy listener to which this traffic should be redirected
+  /// to.
+  listener: ToPortListener?
+
+  /// OriginatingTLS is the TLS context for the connections originated by the L7 proxy. For egress policy
+  /// this specifies the client-side TLS parameters for the upstream connection originating from the L7
+  /// proxy to the remote destination. For ingress policy this specifies the client-side TLS parameters
+  /// for the connection from the L7 proxy to the local endpoint.
+  originatingTLS: ToPortOriginatingTLS?
+
+  /// Ports is a list of L4 port/protocol
+  ports: Listing<ToPortPort>(length <= 40)?
+
+  /// Rules is a list of additional port level rules which must be met in order for the PortRule to allow
+  /// the traffic. If omitted or empty, no layer 7 rules are enforced.
+  rules: ToPortRules?
+
+  /// ServerNames is a list of allowed TLS SNI values. If not empty, then TLS must be present and one of
+  /// the provided SNIs must be indicated in the TLS handshake.
+  serverNames: Listing<String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))>(!isEmpty)?
+
+  /// TerminatingTLS is the TLS context for the connection terminated by the L7 proxy. For egress policy
+  /// this specifies the server-side TLS parameters to be applied on the connections originated from the
+  /// local endpoint and terminated by the L7 proxy. For ingress policy this specifies the server-side
+  /// TLS parameters to be applied on the connections originated from a remote source and terminated by
+  /// the L7 proxy.
+  terminatingTLS: ToPortTerminatingTLS?
+}
+
+/// listener specifies the name of a custom Envoy listener to which this traffic should be redirected to.
+class ToPortListener {
+  /// EnvoyConfig is a reference to the CEC or CCEC resource in which the listener is defined.
+  envoyConfig: ListenerEnvoyConfig
+
+  /// Name is the name of the listener.
+  name: String(!isEmpty)
+
+  /// Priority for this Listener that is used when multiple rules would apply different listeners to a
+  /// policy map entry. Behavior of this is implementation dependent.
+  priority: Int(isBetween(1, 100))?
+}
+
+/// EnvoyConfig is a reference to the CEC or CCEC resource in which the listener is defined.
+class ListenerEnvoyConfig {
+  /// Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+  /// CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+  /// respectively. The only case this is currently explicitly needed is when referring to a
+  /// CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener from a
+  /// cluster scoped policy is not allowed.
+  kind: ("CiliumEnvoyConfig"|"CiliumClusterwideEnvoyConfig")?
+
+  /// Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where the
+  /// listener is defined in.
+  name: String(!isEmpty)
+}
+
+/// OriginatingTLS is the TLS context for the connections originated by the L7 proxy. For egress policy
+/// this specifies the client-side TLS parameters for the upstream connection originating from the L7
+/// proxy to the remote destination. For ingress policy this specifies the client-side TLS parameters for
+/// the connection from the L7 proxy to the local endpoint.
+class ToPortOriginatingTLS {
+  /// Certificate is the file name or k8s secret item name for the certificate chain. If omitted,
+  /// 'tls.crt' is assumed, if it exists. If given, the item must exist.
+  certificate: String?
+
+  /// PrivateKey is the file name or k8s secret item name for the private key matching the certificate
+  /// chain. If omitted, 'tls.key' is assumed, if it exists. If given, the item must exist.
+  privateKey: String?
+
+  /// Secret is the secret that contains the certificates and private key for the TLS context. By
+  /// default, Cilium will search in this secret for the following items: - 'ca.crt' - Which represents
+  /// the trusted CA to verify remote source. - 'tls.crt' - Which represents the public key certificate.
+  /// - 'tls.key' - Which represents the private key matching the public key certificate.
+  secret: TerminatingTLSSecret
+
+  /// TrustedCA is the file name or k8s secret item name for the trusted CA. If omitted, 'ca.crt' is
+  /// assumed, if it exists. If given, the item must exist.
+  trustedCA: String?
+}
+
+/// Secret is the secret that contains the certificates and private key for the TLS context. By default,
+/// Cilium will search in this secret for the following items: - 'ca.crt' - Which represents the trusted
+/// CA to verify remote source. - 'tls.crt' - Which represents the public key certificate. - 'tls.key' -
+/// Which represents the private key matching the public key certificate.
+class TerminatingTLSSecret {
+  /// Name is the name of the secret.
+  name: String
+
+  /// Namespace is the namespace in which the secret exists. Context of use determines the default value
+  /// if left out (e.g., "default").
+  namespace: String?
+}
+
+/// PortProtocol specifies an L4 port with an optional transport protocol
+class ToPortPort {
+  /// EndPort can only be an L4 port number.
+  endPort: UInt16?
+
+  /// Port can be an L4 port number, or a name in the form of "http" or "http-8080".
+  port: String(matches(Regex("^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$")))?
+
+  /// Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols with transport ports (TCP,
+  /// UDP, SCTP) match.
+  ///
+  /// Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP", "IPV6", "ESP", "AH", "ANY"
+  ///
+  /// Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other extended IP protocols (VRRP,
+  /// IGMP) require the --enable-extended-ip-protocols flag to be set. These protocols do not use
+  /// transport-layer ports.
+  ///
+  /// Matching on ICMP is not supported.
+  ///
+  /// Named port specified for a container may narrow this down, but may not contradict this.
+  protocol: ("TCP"|"UDP"|"SCTP"|"VRRP"|"IGMP"|"GRE"|"IPIP"|"IPV6"|"ESP"|"AH"|"ANY")?
+}
+
+/// Rules is a list of additional port level rules which must be met in order for the PortRule to allow
+/// the traffic. If omitted or empty, no layer 7 rules are enforced.
+class ToPortRules {
+  /// DNS-specific rules.
+  dns: Listing<RulesDn>?
+
+  /// HTTP specific rules.
+  http: Listing<RulesHttp>?
+
+  /// Kafka-specific rules. Deprecated: This beta feature is deprecated and will be removed in a future
+  /// release.
+  kafka: Listing<RulesKafka>?
+
+  /// Key-value pair rules.
+  l7: Listing<Mapping<String, String>>?
+
+  /// Name of the L7 protocol for which the Key-value pair rules apply.
+  l7proto: String?
+}
+
+/// PortRuleDNS is a list of allowed DNS lookups.
+class RulesDn {
+  /// MatchName matches literal DNS names. A trailing "." is automatically added when missing.
+  matchName: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_]+[.]?)+$")))?
+
+  /// MatchPattern allows using wildcards to match DNS names. All wildcards are case insensitive. The
+  /// wildcards are: - "*" matches 0 or more DNS valid characters, and may occur anywhere in the pattern.
+  /// As a special case a "*" as the leftmost character, without a following "." matches all subdomains
+  /// as well as the name to the right. A trailing "." is automatically added when missing. - "**." is a
+  /// special prefix which matches all multilevel subdomains in the prefix.
+  ///
+  /// Examples: 1. `*.cilium.io` matches subdomains of cilium at that level www.cilium.io and
+  /// blog.cilium.io match, cilium.io and google.com do not 2. `*cilium.io` matches cilium.io and all
+  /// subdomains ends with "cilium.io" except those containing "." separator, subcilium.io and
+  /// sub-cilium.io match, www.cilium.io and blog.cilium.io does not 3. `sub*.cilium.io` matches
+  /// subdomains of cilium where the subdomain component begins with "sub". sub.cilium.io and
+  /// subdomain.cilium.io match while www.cilium.io, blog.cilium.io, cilium.io and google.com do not 4.
+  /// `**.cilium.io` matches all multilevel subdomains of cilium.io. "app.cilium.io" and
+  /// "test.app.cilium.io" match but not "cilium.io"
+  matchPattern: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))?
+}
+
+/// PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty
+/// or missing, the rule does not have any effect.
+///
+/// All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the
+/// egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it
+/// can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+class RulesHttp {
+  /// HeaderMatches is a list of HTTP headers which must be present and match against the given values.
+  /// Mismatch field can be used to specify what to do when there is no match.
+  headerMatches: Listing<HttpHeaderMatch>?
+
+  /// Headers is a list of HTTP headers which must be present in the request. If omitted or empty,
+  /// requests are allowed regardless of headers present.
+  headers: Listing<String>?
+
+  /// Host is an extended POSIX regex matched against the host header of a request. Examples:
+  ///
+  /// - foo.bar.com will match the host fooXbar.com or foo-bar.com - foo\.bar\.com will only match the
+  /// host foo.bar.com
+  ///
+  /// If omitted or empty, the value of the host header is ignored.
+  host: String?
+
+  /// Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST",
+  /// "PUT", "PATCH", "DELETE", ...
+  ///
+  /// If omitted or empty, all methods are allowed.
+  method: String?
+
+  /// Path is an extended POSIX regex matched against the path of a request. Currently it can contain
+  /// characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+  ///
+  /// If omitted or empty, all paths are all allowed.
+  path: String?
+}
+
+/// HeaderMatch extends the HeaderValue for matching requirement of a named header field against an
+/// immediate string or a secret value. If none of the optional fields is present, then the header value
+/// is not matched, only presence of the header is enough.
+class HttpHeaderMatch {
+  /// Mismatch identifies what to do in case there is no match. The default is to drop the request.
+  /// Otherwise the overall rule is still considered as matching, but the mismatches are logged in the
+  /// access log.
+  mismatch: ("LOG"|"ADD"|"DELETE"|"REPLACE")?
+
+  /// Name identifies the header.
+  name: String(!isEmpty)
+
+  /// Secret refers to a secret that contains the value to be matched against. The secret must only
+  /// contain one entry. If the referred secret does not exist, and there is no "Value" specified, the
+  /// match will fail.
+  secret: HttpHeaderMatchSecret?
+
+  /// Value matches the exact value of the header. Can be specified either alone or together with
+  /// "Secret"; will be used as the header value if the secret can not be found in the latter case.
+  value: String?
+}
+
+/// Secret refers to a secret that contains the value to be matched against. The secret must only contain
+/// one entry. If the referred secret does not exist, and there is no "Value" specified, the match will
+/// fail.
+class HttpHeaderMatchSecret {
+  /// Name is the name of the secret.
+  name: String
+
+  /// Namespace is the namespace in which the secret exists. Context of use determines the default value
+  /// if left out (e.g., "default").
+  namespace: String?
+}
+
+/// PortRule is a list of Kafka protocol constraints. All fields are optional, if all fields are empty or
+/// missing, the rule will match all Kafka messages.
+class RulesKafka {
+  /// APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch",
+  /// "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+  ///
+  /// If omitted or empty, and if Role is not specified, then all keys are allowed.
+  apiKey: String?
+
+  /// APIVersion is the version matched against the api version of the Kafka message. If set, it has to
+  /// be a string representing a positive integer.
+  ///
+  /// If omitted or empty, all versions are allowed.
+  apiVersion: String?
+
+  /// ClientID is the client identifier as provided in the request.
+  ///
+  /// From Kafka protocol documentation: This is a user supplied identifier for the client application.
+  /// The user can use any identifier they like and it will be used when logging errors, monitoring
+  /// aggregates, etc. For example, one might want to monitor not just the requests per second overall,
+  /// but the number coming from each client application (each of which could reside on multiple
+  /// servers). This id acts as a logical grouping across all requests from a particular client.
+  ///
+  /// If omitted or empty, all client identifiers are allowed.
+  clientID: String?
+
+  /// Role is a case-insensitive string and describes a group of API keys necessary to perform certain
+  /// higher-level Kafka operations such as "produce" or "consume". A Role automatically expands into all
+  /// APIKeys required to perform the specified higher-level operation.
+  ///
+  /// The following values are supported: - "produce": Allow producing to the topics specified in the
+  /// rule - "consume": Allow consuming from the topics specified in the rule
+  ///
+  /// This field is incompatible with the APIKey field, i.e APIKey and Role cannot both be specified in
+  /// the same rule.
+  ///
+  /// If omitted or empty, and if APIKey is not specified, then all keys are allowed.
+  role: ("produce"|"consume")?
+
+  /// Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then
+  /// all topics must be allowed or the message will be rejected.
+  ///
+  /// This constraint is ignored if the matched request message type doesn't contain any topic. Maximum
+  /// size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z,
+  /// 0-9, -, . and _.
+  ///
+  /// Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was
+  /// changed from 255 to 249. For compatibility reasons we are using 255.
+  ///
+  /// If omitted or empty, all topics are allowed.
+  topic: String(length <= 255)?
+}
+
+class RulesRulesAlternate0 {
+  http: Null
+}
+
+class RulesRulesAlternate1 {
+  kafka: Null
+}
+
+class RulesRulesAlternate2 {
+  dns: Null
+}
+
+class RulesRulesAlternate3 {
+  l7proto: Null
+}
+
+/// TerminatingTLS is the TLS context for the connection terminated by the L7 proxy. For egress policy
+/// this specifies the server-side TLS parameters to be applied on the connections originated from the
+/// local endpoint and terminated by the L7 proxy. For ingress policy this specifies the server-side TLS
+/// parameters to be applied on the connections originated from a remote source and terminated by the L7
+/// proxy.
+class ToPortTerminatingTLS {
+  /// Certificate is the file name or k8s secret item name for the certificate chain. If omitted,
+  /// 'tls.crt' is assumed, if it exists. If given, the item must exist.
+  certificate: String?
+
+  /// PrivateKey is the file name or k8s secret item name for the private key matching the certificate
+  /// chain. If omitted, 'tls.key' is assumed, if it exists. If given, the item must exist.
+  privateKey: String?
+
+  /// Secret is the secret that contains the certificates and private key for the TLS context. By
+  /// default, Cilium will search in this secret for the following items: - 'ca.crt' - Which represents
+  /// the trusted CA to verify remote source. - 'tls.crt' - Which represents the public key certificate.
+  /// - 'tls.key' - Which represents the private key matching the public key certificate.
+  secret: TerminatingTLSSecret
+
+  /// TrustedCA is the file name or k8s secret item name for the trusted CA. If omitted, 'ca.crt' is
+  /// assumed, if it exists. If given, the item must exist.
+  trustedCA: String?
+}
+
+/// Service selects policy targets that are bundled as part of a logical load-balanced service.
+///
+/// Currently only Kubernetes-based Services are supported.
+class EgressDenyToService {
+  /// K8sService selects service by name and namespace pair
+  k8sService: ToServiceK8sService?
+
+  /// K8sServiceSelector selects services by k8s labels and namespace
+  k8sServiceSelector: ToServiceK8sServiceSelector?
+}
+
+/// K8sService selects service by name and namespace pair
+class ToServiceK8sService {
+  namespace: String?
+
+  serviceName: String?
+}
+
+/// K8sServiceSelector selects services by k8s labels and namespace
+class ToServiceK8sServiceSelector {
+  namespace: String?
+
+  /// ServiceSelector is a label selector for k8s services
+  selector: K8sServiceSelectorSelector
+}
+
+/// ServiceSelector is a label selector for k8s services
+class K8sServiceSelectorSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// EgressDenyRule contains all rule types which can be applied at egress, i.e. network traffic that
+/// originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members of the structure are specified, then all members must match in order for the
+/// rule to take effect.
+///
+/// - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are mutually exclusive. Only
+/// one of these members may be present within an individual rule.
+class SpecEgressDeny {
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// not allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" is not allowed to initiate type 8 ICMP
+  /// connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections. Only connections destined for outside of the cluster and not targeting the host will
+  /// be subject to CIDR rules. This will match on the destination IP address of outgoing connections.
+  /// Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are
+  /// allowed between ToCIDR and ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24
+  toCIDR: Listing<String>?
+
+  /// ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections to in addition to connections which are allowed via ToEndpoints, along with a list of
+  /// subnets contained within their corresponding IP block to which traffic should not be allowed. This
+  /// will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or
+  /// into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+  /// ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+  toCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoints subject
+  /// to the rule are allowed to communicate.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" can communicate with any endpoint carrying the
+  /// label "role=backend".
+  ///
+  /// Note that while an empty non-nil ToEndpoints does not select anything, nil ToEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  toEndpoints: Listing<FromNode>?
+
+  /// ToEntities is a list of special entities to which the endpoint subject to the rule is allowed to
+  /// initiate connections. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  toEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// ToGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: toGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  toGroups: Listing<IngressDenyFromGroup>?
+
+  /// ToNodes is a list of nodes identified by an EndpointSelector to which endpoints subject to the rule
+  /// is allowed to communicate.
+  toNodes: Listing<FromNode>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is not allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" is not allowed to initiate connections to
+  /// destination port 8080/tcp
+  toPorts: Listing<IngressDenyToPort>?
+
+  /// Deprecated.
+  toRequires: Listing<String>(isEmpty)?
+
+  /// ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate
+  /// connections. Currently Cilium only supports toServices for K8s services.
+  toServices: Listing<EgressDenyToService>?
+}
+
+/// PortDenyRule is a list of ports/protocol that should be used for deny policies. This structure lacks
+/// the L7Rules since it's not supported in deny policies.
+class IngressDenyToPort {
+  /// Ports is a list of L4 port/protocol
+  ports: Listing<ToPortPort>?
+}
+
+/// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a default
+/// deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy to be
+/// dropped.
+///
+/// If not specified, the default is true for each traffic direction that has rules, and false otherwise.
+/// For example, if a policy only has Ingress or IngressDeny rules, then the default for ingress is true
+/// and egress is false.
+///
+/// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any policy
+/// requests it.
+///
+/// This is useful for creating broad-based network policies that will not cause endpoints to enter
+/// default-deny mode.
+class SpecEnableDefaultDeny {
+  /// Whether or not the endpoint should have a default-deny rule applied to egress traffic.
+  egress: Boolean?
+
+  /// Whether or not the endpoint should have a default-deny rule applied to ingress traffic.
+  ingress: Boolean?
+}
+
+/// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+/// NodeSelector cannot be both empty and are mutually exclusive.
+class SpecEndpointSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that
+/// originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members are set, all of them need to match in order for the rule to take effect.
+///
+/// - FromEndpoints, FromCIDR, FromCIDRSet and FromEntities are mutually exclusive. Only one of these
+/// members may be present within an individual rule.
+class SpecIngres {
+  /// Authentication is the required authentication type for the allowed traffic, if any.
+  authentication: IngresAuthentication?
+
+  /// FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from. Only connections which do *not* originate from the cluster or from the local host
+  /// are subject to CIDR rules. In order to allow in-cluster connectivity, use the FromEndpoints field.
+  /// This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or
+  /// into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and
+  /// FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.3.9.1
+  fromCIDR: Listing<String>?
+
+  /// FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from in addition to FromEndpoints, along with a list of subnets contained within their
+  /// corresponding IP block from which traffic should not be allowed. This will match on the source IP
+  /// address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no
+  /// ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+  fromCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to
+  /// communicate with the endpoint subject to the rule.
+  ///
+  /// Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the
+  /// label "role=frontend".
+  ///
+  /// Note that while an empty non-nil FromEndpoints does not select anything, nil FromEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  fromEndpoints: Listing<FromNode>?
+
+  /// FromEntities is a list of special entities which the endpoint subject to the rule is allowed to
+  /// receive connections from. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  fromEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// FromGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: FromGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  fromGroups: Listing<IngressDenyFromGroup>?
+
+  /// FromNodes is a list of nodes identified by an EndpointSelector which are allowed to communicate
+  /// with the endpoint subject to the rule.
+  fromNodes: Listing<FromNode>?
+
+  /// Deprecated.
+  fromRequires: Listing<String>(isEmpty)?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can only accept incoming type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port
+  /// 80/tcp.
+  toPorts: Listing<ToPort>?
+}
+
+/// IngressDenyRule contains all rule types which can be applied at ingress, i.e. network traffic that
+/// originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members are set, all of them need to match in order for the rule to take effect.
+///
+/// - FromEndpoints, FromCIDR, FromCIDRSet, FromGroups and FromEntities are mutually exclusive. Only one
+/// of these members may be present within an individual rule.
+class SpecIngressDeny {
+  /// FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from. Only connections which do *not* originate from the cluster or from the local host
+  /// are subject to CIDR rules. In order to allow in-cluster connectivity, use the FromEndpoints field.
+  /// This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or
+  /// into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and
+  /// FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.3.9.1
+  fromCIDR: Listing<String>?
+
+  /// FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from in addition to FromEndpoints, along with a list of subnets contained within their
+  /// corresponding IP block from which traffic should not be allowed. This will match on the source IP
+  /// address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no
+  /// ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+  fromCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to
+  /// communicate with the endpoint subject to the rule.
+  ///
+  /// Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the
+  /// label "role=frontend".
+  ///
+  /// Note that while an empty non-nil FromEndpoints does not select anything, nil FromEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  fromEndpoints: Listing<FromNode>?
+
+  /// FromEntities is a list of special entities which the endpoint subject to the rule is allowed to
+  /// receive connections from. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  fromEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// FromGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: FromGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  fromGroups: Listing<IngressDenyFromGroup>?
+
+  /// FromNodes is a list of nodes identified by an EndpointSelector which are allowed to communicate
+  /// with the endpoint subject to the rule.
+  fromNodes: Listing<FromNode>?
+
+  /// Deprecated.
+  fromRequires: Listing<String>(isEmpty)?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// not allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can not accept incoming type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is not allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can not accept incoming connections on port
+  /// 80/tcp.
+  toPorts: Listing<IngressDenyToPort>?
+}
+
+/// Label is the Cilium's representation of a container label.
+class SpecLabel {
+  key: String
+
+  /// Source can be one of the above values (e.g.: LabelSourceContainer).
+  source: String?
+
+  value: String?
+}
+
+/// Log specifies custom policy-specific Hubble logging configuration.
+class SpecLog {
+  /// Value is a free-form string that is included in Hubble flows that match this policy. The string is
+  /// limited to 32 printable characters.
+  value: String(length <= 32, matches(Regex(#"^\PC*$"#)))?
+}
+
+/// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+/// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+/// CiliumClusterwideNetworkPolicies.
+class SpecNodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+class `[]Alternate0` {
+  ingress: Null
+}
+
+class `[]Alternate1` {
+  ingressDeny: Null
+}
+
+class `[]Alternate2` {
+  egress: Null
+}
+
+class `[]Alternate3` {
+  egressDeny: Null
+}
+
+/// Rule is a policy rule which must be applied to all endpoints which match the labels contained in the
+/// endpointSelector
+///
+/// Each rule is split into an ingress section which contains all rules applicable at ingress, and an
+/// egress section applicable at egress. For rule types such as `L4Rule` and `CIDR` which can be applied
+/// at both ingress and egress, both ingress and egress side have to either specifically allow the
+/// connection or one side has to be omitted.
+///
+/// Either ingress, egress, or both can be provided. If both ingress and egress are omitted, the rule has
+/// no effect.
+class ItemSpec {
+  /// Description is a free form string, it can be used by the creator of the rule to store human
+  /// readable explanation of the purpose of this rule. Rules cannot be identified by comment.
+  description: String?
+
+  /// Egress is a list of EgressRule which are enforced at egress. If omitted or empty, this rule does
+  /// not apply at egress.
+  egress: Listing<SpecEgres>?
+
+  /// EgressDeny is a list of EgressDenyRule which are enforced at egress. Any rule inserted here will be
+  /// denied regardless of the allowed egress rules in the 'egress' field. If omitted or empty, this rule
+  /// does not apply at egress.
+  egressDeny: Listing<SpecEgressDeny>?
+
+  /// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a
+  /// default deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy
+  /// to be dropped.
+  ///
+  /// If not specified, the default is true for each traffic direction that has rules, and false
+  /// otherwise. For example, if a policy only has Ingress or IngressDeny rules, then the default for
+  /// ingress is true and egress is false.
+  ///
+  /// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any
+  /// policy requests it.
+  ///
+  /// This is useful for creating broad-based network policies that will not cause endpoints to enter
+  /// default-deny mode.
+  enableDefaultDeny: SpecEnableDefaultDeny?
+
+  /// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive.
+  endpointSelector: SpecEndpointSelector?
+
+  /// Ingress is a list of IngressRule which are enforced at ingress. If omitted or empty, this rule does
+  /// not apply at ingress.
+  ingress: Listing<SpecIngres>?
+
+  /// IngressDeny is a list of IngressDenyRule which are enforced at ingress. Any rule inserted here will
+  /// be denied regardless of the allowed ingress rules in the 'ingress' field. If omitted or empty, this
+  /// rule does not apply at ingress.
+  ingressDeny: Listing<SpecIngressDeny>?
+
+  /// Labels is a list of optional strings which can be used to re-identify the rule or to store
+  /// metadata. It is possible to lookup or delete strings based on labels. Labels are not required to be
+  /// unique, multiple rules can have overlapping or identical labels.
+  labels: Listing<SpecLabel>?
+
+  /// Log specifies custom policy-specific Hubble logging configuration.
+  log: SpecLog?
+
+  /// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+  /// CiliumClusterwideNetworkPolicies.
+  nodeSelector: SpecNodeSelector?
+}
+
+/// Status is the status of the Cilium policy rule.
+///
+/// The reason this field exists in this structure is due a bug in the k8s code-generator that doesn't
+/// create a `UpdateStatus` method because the field does not exist in the structure.
+class Status {
+  conditions: Listing<Condition>?
+
+  /// DerivativePolicies is the status of all policies derived from the Cilium policy
+  derivativePolicies: Mapping<String, DerivativePolicies>?
+}
+
+class Condition {
+  /// The last time the condition transitioned from one status to another.
+  lastTransitionTime: String?
+
+  /// A human readable message indicating details about the transition.
+  message: String?
+
+  /// The reason for the condition's last transition.
+  reason: String?
+
+  /// The status of the condition, one of True, False, or Unknown
+  status: String
+
+  /// The type of the policy condition
+  type: String
+}
+
+/// CiliumNetworkPolicyNodeStatus is the status of a Cilium policy rule for a specific node.
+class DerivativePolicies {
+  /// Annotations corresponds to the Annotations in the ObjectMeta of the CNP that have been realized on
+  /// the node for CNP. That is, if a CNP has been imported and has been assigned annotation X=Y by the
+  /// user, Annotations in CiliumNetworkPolicyNodeStatus will be X=Y once the CNP that was imported
+  /// corresponding to Annotation X=Y has been realized on the node.
+  annotations: Mapping<String, String>?
+
+  /// Enforcing is set to true once all endpoints present at the time the policy has been imported are
+  /// enforcing this policy.
+  enforcing: Boolean?
+
+  /// Error describes any error that occurred when parsing or importing the policy, or realizing the
+  /// policy for the endpoints to which it applies on the node.
+  error: String?
+
+  /// LastUpdated contains the last time this status was updated
+  lastUpdated: String?
+
+  /// Revision is the policy revision of the repository which first implemented this policy.
+  localPolicyRevision: Int?
+
+  /// OK is true when the policy has been parsed and imported successfully into the in-memory policy
+  /// repository on the node.
+  ok: Boolean?
+}

--- a/packages/io.cilium/v2/CiliumClusterwideNetworkPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumClusterwideNetworkPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumClusterwideNetworkPolicy is a Kubernetes third-party resource with an modified version of
 /// CiliumNetworkPolicy which is cluster scoped rather than namespace scoped.
 ///

--- a/packages/io.cilium/v2/CiliumEgressGatewayPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumEgressGatewayPolicy.pkl
@@ -1,0 +1,181 @@
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml>.
+module io.cilium.v2.CiliumEgressGatewayPolicy
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumEgressGatewayPolicy"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec?
+
+class Spec {
+  /// DestinationCIDRs is a list of destination CIDRs for destination IP addresses. If a destination IP
+  /// matches any one CIDR, it will be selected.
+  destinationCIDRs: Listing<String(matches(Regex(#"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$|^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$"#)))>
+
+  /// EgressGateway is the gateway node responsible for SNATing traffic. In case multiple nodes are a
+  /// match for the given set of labels, the first node in lexical ordering based on their name will be
+  /// selected.
+  egressGateway: EgressGateway
+
+  /// Optional list of gateway nodes responsible for SNATing traffic. If this field has any entries the
+  /// contents of the egressGateway field will be ignored. In case multiple nodes are a match for the
+  /// given set of labels in each entry, the first node in lexical ordering based on their name will be
+  /// selected for each entry.
+  ///
+  /// Default if undefined: `{}`
+  egressGateways: Listing<SpecEgressGateway>?
+
+  /// ExcludedCIDRs is a list of destination CIDRs that will be excluded from the egress gateway
+  /// redirection and SNAT logic. Should be a subset of destinationCIDRs otherwise it will not have any
+  /// effect.
+  excludedCIDRs: Listing<String(matches(Regex(#"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/([0-9]|[1-2][0-9]|3[0-2])$|^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$"#)))>?
+
+  /// Egress represents a list of rules by which egress traffic is filtered from the source pods.
+  selectors: Listing<Selector>
+}
+
+/// EgressGateway is the gateway node responsible for SNATing traffic. In case multiple nodes are a match
+/// for the given set of labels, the first node in lexical ordering based on their name will be selected.
+class EgressGateway {
+  /// EgressIP is the source IP address that the egress traffic is SNATed with.
+  ///
+  /// Example: When set to "192.168.1.100", matching egress traffic will be redirected to the node
+  /// matching the NodeSelector field and SNATed with IP address 192.168.1.100.
+  ///
+  /// When none of the Interface or EgressIP fields is specified, the policy will use the first IPv4
+  /// assigned to the interface with the default route.
+  egressIP: String?
+
+  /// Interface is the network interface to which the egress IP address that the traffic is SNATed with
+  /// is assigned.
+  ///
+  /// Example: When set to "eth1", matching egress traffic will be redirected to the node matching the
+  /// NodeSelector field and SNATed with the first IPv4 address assigned to the eth1 interface.
+  ///
+  /// When none of the Interface or EgressIP fields is specified, the policy will use the first IPv4
+  /// assigned to the interface with the default route.
+  interface: String?
+
+  /// This is a label selector which selects the node that should act as egress gateway for the given
+  /// policy. In case multiple nodes are selected, only the first one in the lexical ordering over the
+  /// node names will be used. This field follows standard label selector semantics.
+  nodeSelector: EgressGatewayNodeSelector
+}
+
+/// This is a label selector which selects the node that should act as egress gateway for the given
+/// policy. In case multiple nodes are selected, only the first one in the lexical ordering over the node
+/// names will be used. This field follows standard label selector semantics.
+class EgressGatewayNodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// EgressGateway identifies the node that should act as egress gateway for a given egress Gateway
+/// policy. In addition to that it also specifies the configuration of said node (which egress IP or
+/// network interface should be used to SNAT traffic).
+class SpecEgressGateway {
+  /// EgressIP is the source IP address that the egress traffic is SNATed with.
+  ///
+  /// Example: When set to "192.168.1.100", matching egress traffic will be redirected to the node
+  /// matching the NodeSelector field and SNATed with IP address 192.168.1.100.
+  ///
+  /// When none of the Interface or EgressIP fields is specified, the policy will use the first IPv4
+  /// assigned to the interface with the default route.
+  egressIP: String?
+
+  /// Interface is the network interface to which the egress IP address that the traffic is SNATed with
+  /// is assigned.
+  ///
+  /// Example: When set to "eth1", matching egress traffic will be redirected to the node matching the
+  /// NodeSelector field and SNATed with the first IPv4 address assigned to the eth1 interface.
+  ///
+  /// When none of the Interface or EgressIP fields is specified, the policy will use the first IPv4
+  /// assigned to the interface with the default route.
+  interface: String?
+
+  /// This is a label selector which selects the node that should act as egress gateway for the given
+  /// policy. In case multiple nodes are selected, only the first one in the lexical ordering over the
+  /// node names will be used. This field follows standard label selector semantics.
+  nodeSelector: EgressGatewayNodeSelector
+}
+
+class Selector {
+  /// Selects Namespaces using cluster-scoped labels. This field follows standard label selector
+  /// semantics; if present but empty, it selects all namespaces.
+  namespaceSelector: NamespaceSelector?
+
+  /// This is a label selector which selects Pods by Node. This field follows standard label selector
+  /// semantics; if present but empty, it selects all nodes.
+  nodeSelector: NodeSelector?
+
+  /// This is a label selector which selects Pods. This field follows standard label selector semantics;
+  /// if present but empty, it selects all pods.
+  podSelector: PodSelector?
+}
+
+/// Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics;
+/// if present but empty, it selects all namespaces.
+class NamespaceSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// This is a label selector which selects Pods by Node. This field follows standard label selector
+/// semantics; if present but empty, it selects all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// This is a label selector which selects Pods. This field follows standard label selector semantics; if
+/// present but empty, it selects all pods.
+class PodSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}

--- a/packages/io.cilium/v2/CiliumEgressGatewayPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumEgressGatewayPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// This module was generated from the CustomResourceDefinition at
 /// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml>.
 module io.cilium.v2.CiliumEgressGatewayPolicy

--- a/packages/io.cilium/v2/CiliumEndpoint.pkl
+++ b/packages/io.cilium/v2/CiliumEndpoint.pkl
@@ -1,0 +1,263 @@
+/// CiliumEndpoint is the status of a Cilium policy rule.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml>.
+module io.cilium.v2.CiliumEndpoint
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumEndpoint"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// EndpointStatus is the status of a Cilium endpoint.
+status: Status?
+
+/// EndpointStatus is the status of a Cilium endpoint.
+class Status {
+  /// Controllers is the list of failing controllers for this endpoint.
+  controllers: Listing<Controller>?
+
+  /// Encryption is the encryption configuration of the node
+  encryption: Encryption?
+
+  /// ExternalIdentifiers is a set of identifiers to identify the endpoint apart from the pod name. This
+  /// includes container runtime IDs.
+  `external-identifiers`: ExternalIdentifiers?
+
+  /// Health is the overall endpoint & subcomponent health.
+  health: Health?
+
+  /// ID is the cilium-agent-local ID of the endpoint.
+  id: Int?
+
+  /// Identity is the security identity associated with the endpoint
+  identity: Identity?
+
+  /// Log is the list of the last few warning and error log entries
+  log: Listing<Log>?
+
+  /// NamedPorts List of named Layer 4 port and protocol pairs which will be used in Network Policy
+  /// specs.
+  ///
+  /// swagger:model NamedPorts
+  `named-ports`: Listing<NamedPort>?
+
+  /// Networking is the networking properties of the endpoint.
+  networking: Networking?
+
+  /// EndpointPolicy represents the endpoint's policy by listing all allowed ingress and egress
+  /// identities in combination with L4 port and protocol.
+  policy: Policy?
+
+  /// ServiceAccount is the service account associated with the endpoint
+  `service-account`: String?
+
+  /// State is the state of the endpoint.
+  state: (
+    "creating"
+    |"waiting-for-identity"
+    |"not-ready"
+    |"waiting-to-regenerate"
+    |"regenerating"
+    |"restoring"
+    |"ready"
+    |"disconnecting"
+    |"disconnected"
+    |"invalid")?
+}
+
+/// ControllerStatus is the status of a failing controller.
+class Controller {
+  /// Configuration is the controller configuration
+  configuration: Configuration?
+
+  /// Name is the name of the controller
+  name: String?
+
+  /// Status is the status of the controller
+  status: ControllerStatus?
+
+  /// UUID is the UUID of the controller
+  uuid: String?
+}
+
+/// Configuration is the controller configuration
+class Configuration {
+  /// Retry on error
+  `error-retry`: Boolean?
+
+  /// Base error retry back-off time Format: duration
+  `error-retry-base`: Int?
+
+  /// Regular synchronization interval Format: duration
+  interval: Int?
+}
+
+/// Status is the status of the controller
+class ControllerStatus {
+  `consecutive-failure-count`: Int?
+
+  `failure-count`: Int?
+
+  `last-failure-msg`: String?
+
+  `last-failure-timestamp`: String?
+
+  `last-success-timestamp`: String?
+
+  `success-count`: Int?
+}
+
+/// Encryption is the encryption configuration of the node
+class Encryption {
+  /// Key is the index to the key to use for encryption or 0 if encryption is disabled.
+  key: Int?
+}
+
+/// ExternalIdentifiers is a set of identifiers to identify the endpoint apart from the pod name. This
+/// includes container runtime IDs.
+class ExternalIdentifiers {
+  /// ID assigned to this attachment by container runtime
+  `cni-attachment-id`: String?
+
+  /// ID assigned by container runtime (deprecated, may not be unique)
+  `container-id`: String?
+
+  /// Name assigned to container (deprecated, may not be unique)
+  `container-name`: String?
+
+  /// Docker endpoint ID
+  `docker-endpoint-id`: String?
+
+  /// Docker network ID
+  `docker-network-id`: String?
+
+  /// K8s namespace for this endpoint (deprecated, may not be unique)
+  `k8s-namespace`: String?
+
+  /// K8s pod name for this endpoint (deprecated, may not be unique)
+  `k8s-pod-name`: String?
+
+  /// K8s pod for this endpoint (deprecated, may not be unique)
+  `pod-name`: String?
+}
+
+/// Health is the overall endpoint & subcomponent health.
+class Health {
+  /// bpf
+  bpf: String?
+
+  /// Is this endpoint reachable
+  connected: Boolean?
+
+  /// overall health
+  overallHealth: String?
+
+  /// policy
+  policy: String?
+}
+
+/// Identity is the security identity associated with the endpoint
+class Identity {
+  /// ID is the numeric identity of the endpoint
+  id: Int?
+
+  /// Labels is the list of labels associated with the identity
+  labels: Listing<String>?
+}
+
+/// EndpointStatusChange Indication of a change of status
+///
+/// swagger:model EndpointStatusChange
+class Log {
+  /// Code indicate type of status change Enum: ["ok","failed"]
+  code: String?
+
+  /// Status message
+  message: String?
+
+  /// state
+  state: String?
+
+  /// Timestamp when status change occurred
+  timestamp: String?
+}
+
+/// Port Layer 4 port / protocol pair
+///
+/// swagger:model Port
+class NamedPort {
+  /// Optional layer 4 port name
+  name: String?
+
+  /// Layer 4 port number
+  port: Int?
+
+  /// Layer 4 protocol Enum: ["TCP","UDP","SCTP","ICMP","ICMPV6","ANY"]
+  protocol: String?
+}
+
+/// Networking is the networking properties of the endpoint.
+class Networking {
+  /// IP4/6 addresses assigned to this Endpoint
+  addressing: Listing<Addressing>
+
+  /// NodeIP is the IP of the node the endpoint is running on. The IP must be reachable between nodes.
+  node: String?
+}
+
+/// AddressPair is a pair of IPv4 and/or IPv6 address.
+class Addressing {
+  ipv4: String?
+
+  ipv6: String?
+}
+
+/// EndpointPolicy represents the endpoint's policy by listing all allowed ingress and egress identities
+/// in combination with L4 port and protocol.
+class Policy {
+  /// EndpointPolicyDirection is the list of allowed identities per direction.
+  egress: Ingress?
+
+  /// EndpointPolicyDirection is the list of allowed identities per direction.
+  ingress: Ingress?
+}
+
+/// EndpointPolicyDirection is the list of allowed identities per direction.
+class Ingress {
+  /// Deprecated
+  adding: Listing<Removing>?
+
+  /// AllowedIdentityList is a list of IdentityTuples that species peers that are allowed.
+  allowed: Listing<Removing>?
+
+  /// DenyIdentityList is a list of IdentityTuples that species peers that are denied.
+  denied: Listing<Removing>?
+
+  enforcing: Boolean
+
+  /// Deprecated
+  removing: Listing<Removing>?
+
+  /// EndpointPolicyState defines the state of the Policy mode: "enforcing", "non-enforcing", "disabled"
+  state: String?
+}
+
+/// IdentityTuple specifies a peer by identity, destination port and protocol.
+class Removing {
+  `dest-port`: Int?
+
+  identity: Int?
+
+  `identity-labels`: Mapping<String, String>?
+
+  protocol: Int?
+}

--- a/packages/io.cilium/v2/CiliumEndpoint.pkl
+++ b/packages/io.cilium/v2/CiliumEndpoint.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumEndpoint is the status of a Cilium policy rule.
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2/CiliumEnvoyConfig.pkl
+++ b/packages/io.cilium/v2/CiliumEnvoyConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// This module was generated from the CustomResourceDefinition at
 /// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumenvoyconfigs.yaml>.
 module io.cilium.v2.CiliumEnvoyConfig

--- a/packages/io.cilium/v2/CiliumEnvoyConfig.pkl
+++ b/packages/io.cilium/v2/CiliumEnvoyConfig.pkl
@@ -1,0 +1,102 @@
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumenvoyconfigs.yaml>.
+module io.cilium.v2.CiliumEnvoyConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumEnvoyConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec?
+
+class Spec {
+  /// BackendServices specifies Kubernetes services whose backends are automatically synced to Envoy
+  /// using EDS. Traffic for these services is not forwarded to an Envoy listener. This allows an Envoy
+  /// listener load balance traffic to these backends while normal Cilium service load balancing takes
+  /// care of balancing traffic for these services at the same time.
+  backendServices: Listing<BackendService>?
+
+  /// NodeSelector is a label selector that determines to which nodes this configuration applies. If nil,
+  /// then this config applies to all nodes.
+  nodeSelector: NodeSelector?
+
+  /// Envoy xDS resources, a list of the following Envoy resource types:
+  /// type.googleapis.com/envoy.config.listener.v3.Listener,
+  /// type.googleapis.com/envoy.config.route.v3.RouteConfiguration,
+  /// type.googleapis.com/envoy.config.cluster.v3.Cluster,
+  /// type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment, and
+  /// type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret.
+  resources: Listing<Dynamic>
+
+  /// Services specifies Kubernetes services for which traffic is forwarded to an Envoy listener for L7
+  /// load balancing. Backends of these services are automatically synced to Envoy usign EDS.
+  services: Listing<Service>?
+}
+
+class BackendService {
+  /// Name is the name of a destination Kubernetes service that identifies traffic to be redirected.
+  name: String
+
+  /// Namespace is the Kubernetes service namespace. In CiliumEnvoyConfig namespace defaults to the
+  /// namespace of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults to "default".
+  namespace: String?
+
+  /// Ports is a set of port numbers, which can be used for filtering in case of underlying is exposing
+  /// multiple port numbers.
+  number: Listing<String>?
+}
+
+/// NodeSelector is a label selector that determines to which nodes this configuration applies. If nil,
+/// then this config applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+class Service {
+  /// Listener specifies the name of the Envoy listener the service traffic is redirected to. The
+  /// listener must be specified in the Envoy 'resources' of the same CiliumEnvoyConfig.
+  ///
+  /// If omitted, the first listener specified in 'resources' is used.
+  listener: String?
+
+  /// Name is the name of a destination Kubernetes service that identifies traffic to be redirected.
+  name: String
+
+  /// Namespace is the Kubernetes service namespace. In CiliumEnvoyConfig namespace this is overridden to
+  /// the namespace of the CEC, In CiliumClusterwideEnvoyConfig namespace defaults to "default".
+  namespace: String?
+
+  /// Ports is a set of service's frontend ports that should be redirected to the Envoy listener. By
+  /// default all frontend ports of the service are redirected.
+  ports: Listing<Int>?
+}

--- a/packages/io.cilium/v2/CiliumIdentity.pkl
+++ b/packages/io.cilium/v2/CiliumIdentity.pkl
@@ -1,0 +1,30 @@
+/// CiliumIdentity is a CRD that represents an identity managed by Cilium. It is intended as a backing
+/// store for identity allocation, acting as the global coordination backend, and can be used in place of
+/// a KVStore (such as etcd). The name of the CRD is the numeric identity and the labels on the CRD
+/// object are the kubernetes sourced labels seen by cilium. This is currently the only label source
+/// possible when running under kubernetes. Non-kubernetes labels are filtered but all labels, from all
+/// sources, are places in the SecurityLabels field. These also include the source and are used to define
+/// the identity. The labels under metav1.ObjectMeta can be used when searching for CiliumIdentity
+/// instances that include particular labels. This can be done with invocations such as:
+///
+/// kubectl get ciliumid -l 'foo=bar'
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml>.
+module io.cilium.v2.CiliumIdentity
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumIdentity"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// SecurityLabels is the source-of-truth set of labels for this identity.
+`security-labels`: Mapping<String, String>

--- a/packages/io.cilium/v2/CiliumIdentity.pkl
+++ b/packages/io.cilium/v2/CiliumIdentity.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumIdentity is a CRD that represents an identity managed by Cilium. It is intended as a backing
 /// store for identity allocation, acting as the global coordination backend, and can be used in place of
 /// a KVStore (such as etcd). The name of the CRD is the numeric identity and the labels on the CRD

--- a/packages/io.cilium/v2/CiliumLoadBalancerIPPool.pkl
+++ b/packages/io.cilium/v2/CiliumLoadBalancerIPPool.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumLoadBalancerIPPool is a Kubernetes third-party resource which is used to defined pools of IPs
 /// which the operator can use to allocate and advertise IPs for Services of type LoadBalancer.
 ///

--- a/packages/io.cilium/v2/CiliumLoadBalancerIPPool.pkl
+++ b/packages/io.cilium/v2/CiliumLoadBalancerIPPool.pkl
@@ -1,0 +1,124 @@
+/// CiliumLoadBalancerIPPool is a Kubernetes third-party resource which is used to defined pools of IPs
+/// which the operator can use to allocate and advertise IPs for Services of type LoadBalancer.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumloadbalancerippools.yaml>.
+module io.cilium.v2.CiliumLoadBalancerIPPool
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumLoadBalancerIPPool"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is a human readable description for a BGP load balancer ip pool.
+spec: Spec
+
+/// Status is the status of the IP Pool.
+///
+/// It might be possible for users to define overlapping IP Pools, we can't validate or enforce
+/// non-overlapping pools during object creation. The Cilium operator will do this validation and update
+/// the status to reflect the ability to allocate IPs from this pool.
+status: Status?
+
+/// Spec is a human readable description for a BGP load balancer ip pool.
+class Spec {
+  /// AllowFirstLastIPs, if set to `Yes` or undefined means that the first and last IPs of each CIDR will
+  /// be allocatable. If `No`, these IPs will be reserved. This field is ignored for /{31,32} and
+  /// /{127,128} CIDRs since reserving the first and last IPs would make the CIDRs unusable.
+  allowFirstLastIPs: ("Yes"|"No")?
+
+  /// Blocks is a list of CIDRs comprising this IP Pool
+  blocks: Listing<Block>?
+
+  /// Disabled, if set to true means that no new IPs will be allocated from this pool. Existing
+  /// allocations will not be removed from services.
+  ///
+  /// Default if undefined: `false`
+  disabled: Boolean?
+
+  /// ServiceSelector selects a set of services which are eligible to receive IPs from this
+  serviceSelector: ServiceSelector?
+}
+
+/// CiliumLoadBalancerIPPoolIPBlock describes a single IP block.
+class Block {
+  cidr: String?
+
+  start: String?
+
+  stop: String?
+}
+
+/// ServiceSelector selects a set of services which are eligible to receive IPs from this
+class ServiceSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Status is the status of the IP Pool.
+///
+/// It might be possible for users to define overlapping IP Pools, we can't validate or enforce
+/// non-overlapping pools during object creation. The Cilium operator will do this validation and update
+/// the status to reflect the ability to allocate IPs from this pool.
+class Status {
+  /// Current service state
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2/CiliumLocalRedirectPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumLocalRedirectPolicy.pkl
@@ -1,0 +1,159 @@
+/// CiliumLocalRedirectPolicy is a Kubernetes Custom Resource that contains a specification to redirect
+/// traffic locally within a node.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml>.
+module io.cilium.v2.CiliumLocalRedirectPolicy
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumLocalRedirectPolicy"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the desired behavior of the local redirect policy.
+spec: Spec?
+
+/// Status is the most recent status of the local redirect policy. It is a read-only field.
+status: Status?
+
+/// Spec is the desired behavior of the local redirect policy.
+class Spec {
+  /// Description can be used by the creator of the policy to describe the purpose of this policy.
+  description: String?
+
+  /// RedirectBackend specifies backend configuration to redirect traffic to. It can not be empty.
+  redirectBackend: RedirectBackend
+
+  /// RedirectFrontend specifies frontend configuration to redirect traffic from. It can not be empty.
+  redirectFrontend: RedirectFrontend
+
+  /// SkipRedirectFromBackend indicates whether traffic matching RedirectFrontend from RedirectBackend
+  /// should skip redirection, and hence the traffic will be forwarded as-is.
+  ///
+  /// The default is false which means traffic matching RedirectFrontend will get redirected from all
+  /// pods, including the RedirectBackend(s).
+  ///
+  /// Example: If RedirectFrontend is configured to "169.254.169.254:80" as the traffic that needs to be
+  /// redirected to backends selected by RedirectBackend, if SkipRedirectFromBackend is set to true,
+  /// traffic going to "169.254.169.254:80" from such backends will not be redirected back to the
+  /// backends. Instead, the matched traffic from the backends will be forwarded to the original
+  /// destination "169.254.169.254:80".
+  ///
+  /// Default if undefined: `false`
+  skipRedirectFromBackend: Boolean?
+}
+
+/// RedirectBackend specifies backend configuration to redirect traffic to. It can not be empty.
+class RedirectBackend {
+  /// LocalEndpointSelector selects node local pod(s) where traffic is redirected to.
+  localEndpointSelector: LocalEndpointSelector
+
+  /// ToPorts is a list of L4 ports with protocol of node local pod(s) where traffic is redirected to.
+  /// When multiple ports are specified, the ports must be named.
+  toPorts: Listing<ToPort>
+}
+
+/// LocalEndpointSelector selects node local pod(s) where traffic is redirected to.
+class LocalEndpointSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// PortInfo specifies L4 port number and name along with the transport protocol
+class ToPort {
+  /// Name is a port name, which must contain at least one [a-z], and may also contain [0-9] and '-'
+  /// anywhere except adjacent to another '-' or in the beginning or the end.
+  name: String(matches(Regex("^([0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$")))?
+
+  /// Port is an L4 port number. The string will be strictly parsed as a single uint16.
+  port: String(matches(Regex("^()([1-9]|[1-5]?[0-9]{2,4}|6[1-4][0-9]{3}|65[1-4][0-9]{2}|655[1-2][0-9]|6553[1-5])$")))
+
+  /// Protocol is the L4 protocol. Accepted values: "TCP", "UDP"
+  protocol: "TCP"|"UDP"
+}
+
+/// RedirectFrontend specifies frontend configuration to redirect traffic from. It can not be empty.
+class RedirectFrontend {
+  /// AddressMatcher is a tuple {IP, port, protocol} that matches traffic to be redirected.
+  addressMatcher: AddressMatcher?
+
+  /// ServiceMatcher specifies Kubernetes service and port that matches traffic to be redirected.
+  serviceMatcher: ServiceMatcher?
+}
+
+/// AddressMatcher is a tuple {IP, port, protocol} that matches traffic to be redirected.
+class AddressMatcher {
+  /// IP is a destination ip address for traffic to be redirected.
+  ///
+  /// Example: When it is set to "169.254.169.254", traffic destined to "169.254.169.254" is redirected.
+  ip: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))
+
+  /// ToPorts is a list of destination L4 ports with protocol for traffic to be redirected. When multiple
+  /// ports are specified, the ports must be named.
+  ///
+  /// Example: When set to Port: "53" and Protocol: UDP, traffic destined to port '53' with UDP protocol
+  /// is redirected.
+  toPorts: Listing<ToPort>
+}
+
+/// ServiceMatcher specifies Kubernetes service and port that matches traffic to be redirected.
+class ServiceMatcher {
+  /// Namespace is the Kubernetes service namespace. The service namespace must match the namespace of
+  /// the parent Local Redirect Policy. For Cluster-wide Local Redirect Policy, this can be any
+  /// namespace.
+  namespace: String
+
+  /// Name is the name of a destination Kubernetes service that identifies traffic to be redirected. The
+  /// service type needs to be ClusterIP.
+  ///
+  /// Example: When this field is populated with 'serviceName:myService', all the traffic destined to the
+  /// cluster IP of this service at the (specified) service port(s) will be redirected.
+  serviceName: String
+
+  /// ToPorts is a list of destination service L4 ports with protocol for traffic to be redirected. If
+  /// not specified, traffic for all the service ports will be redirected. When multiple ports are
+  /// specified, the ports must be named.
+  toPorts: Listing<ToPort>?
+}
+
+class RedirectFrontendAlternate0 {
+  addressMatcher: Null
+}
+
+class RedirectFrontendAlternate1 {
+  serviceMatcher: Null
+}
+
+/// Status is the most recent status of the local redirect policy. It is a read-only field.
+class Status {
+  ok: Boolean?
+}

--- a/packages/io.cilium/v2/CiliumLocalRedirectPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumLocalRedirectPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumLocalRedirectPolicy is a Kubernetes Custom Resource that contains a specification to redirect
 /// traffic locally within a node.
 ///

--- a/packages/io.cilium/v2/CiliumNetworkPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumNetworkPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumNetworkPolicy is a Kubernetes third-party resource with an extended version of NetworkPolicy.
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2/CiliumNetworkPolicy.pkl
+++ b/packages/io.cilium/v2/CiliumNetworkPolicy.pkl
@@ -1,0 +1,1129 @@
+/// CiliumNetworkPolicy is a Kubernetes third-party resource with an extended version of NetworkPolicy.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml>.
+module io.cilium.v2.CiliumNetworkPolicy
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumNetworkPolicy"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the desired Cilium specific rule specification.
+spec: Spec?
+
+/// Specs is a list of desired Cilium specific rule specification.
+specs: Listing<ItemSpec>?
+
+/// Status is the status of the Cilium policy rule
+status: Status?
+
+/// Spec is the desired Cilium specific rule specification.
+class Spec {
+  /// Description is a free form string, it can be used by the creator of the rule to store human
+  /// readable explanation of the purpose of this rule. Rules cannot be identified by comment.
+  description: String?
+
+  /// Egress is a list of EgressRule which are enforced at egress. If omitted or empty, this rule does
+  /// not apply at egress.
+  egress: Listing<SpecEgres>?
+
+  /// EgressDeny is a list of EgressDenyRule which are enforced at egress. Any rule inserted here will be
+  /// denied regardless of the allowed egress rules in the 'egress' field. If omitted or empty, this rule
+  /// does not apply at egress.
+  egressDeny: Listing<SpecEgressDeny>?
+
+  /// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a
+  /// default deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy
+  /// to be dropped.
+  ///
+  /// If not specified, the default is true for each traffic direction that has rules, and false
+  /// otherwise. For example, if a policy only has Ingress or IngressDeny rules, then the default for
+  /// ingress is true and egress is false.
+  ///
+  /// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any
+  /// policy requests it.
+  ///
+  /// This is useful for creating broad-based network policies that will not cause endpoints to enter
+  /// default-deny mode.
+  enableDefaultDeny: SpecEnableDefaultDeny?
+
+  /// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive.
+  endpointSelector: SpecEndpointSelector?
+
+  /// Ingress is a list of IngressRule which are enforced at ingress. If omitted or empty, this rule does
+  /// not apply at ingress.
+  ingress: Listing<SpecIngres>?
+
+  /// IngressDeny is a list of IngressDenyRule which are enforced at ingress. Any rule inserted here will
+  /// be denied regardless of the allowed ingress rules in the 'ingress' field. If omitted or empty, this
+  /// rule does not apply at ingress.
+  ingressDeny: Listing<SpecIngressDeny>?
+
+  /// Labels is a list of optional strings which can be used to re-identify the rule or to store
+  /// metadata. It is possible to lookup or delete strings based on labels. Labels are not required to be
+  /// unique, multiple rules can have overlapping or identical labels.
+  labels: Listing<SpecLabel>?
+
+  /// Log specifies custom policy-specific Hubble logging configuration.
+  log: SpecLog?
+
+  /// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+  /// CiliumClusterwideNetworkPolicies.
+  nodeSelector: SpecNodeSelector?
+}
+
+/// EgressRule contains all rule types which can be applied at egress, i.e. network traffic that
+/// originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members of the structure are specified, then all members must match in order for the
+/// rule to take effect.
+///
+/// - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are mutually exclusive. Only
+/// one of these members may be present within an individual rule.
+class SpecEgres {
+  /// Authentication is the required authentication type for the allowed traffic, if any.
+  authentication: IngresAuthentication?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" is allowed to initiate type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections. Only connections destined for outside of the cluster and not targeting the host will
+  /// be subject to CIDR rules. This will match on the destination IP address of outgoing connections.
+  /// Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are
+  /// allowed between ToCIDR and ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24
+  toCIDR: Listing<String>?
+
+  /// ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections to in addition to connections which are allowed via ToEndpoints, along with a list of
+  /// subnets contained within their corresponding IP block to which traffic should not be allowed. This
+  /// will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or
+  /// into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+  /// ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+  toCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoints subject
+  /// to the rule are allowed to communicate.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" can communicate with any endpoint carrying the
+  /// label "role=backend".
+  ///
+  /// Note that while an empty non-nil ToEndpoints does not select anything, nil ToEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  toEndpoints: Listing<FromNode>?
+
+  /// ToEntities is a list of special entities to which the endpoint subject to the rule is allowed to
+  /// initiate connections. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  toEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// ToFQDN allows whitelisting DNS names in place of IPs. The IPs that result from DNS resolution of
+  /// `ToFQDN.MatchName`s are added to the same EgressRule object as ToCIDRSet entries, and behave
+  /// accordingly. Any L4 and L7 rules within this EgressRule will also apply to these IPs. The DNS -> IP
+  /// mapping is re-resolved periodically from within the cilium-agent, and the IPs in the DNS response
+  /// are effected in the policy for selected pods as-is (i.e. the list of IPs is not modified in any
+  /// way). Note: An explicit rule to allow for DNS traffic is needed for the pods, as ToFQDN counts as
+  /// an egress rule and will enforce egress policy when PolicyEnforcment=default. Note: If the resolved
+  /// IPs are IPs within the kubernetes cluster, the ToFQDN rule will not apply to that IP. Note: ToFQDN
+  /// cannot occur in the same policy as other To* rules.
+  toFQDNs: Listing<EgresToFQDN>?
+
+  /// ToGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: toGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  toGroups: Listing<IngressDenyFromGroup>?
+
+  /// ToNodes is a list of nodes identified by an EndpointSelector to which endpoints subject to the rule
+  /// is allowed to communicate.
+  toNodes: Listing<FromNode>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" is allowed to initiate connections to
+  /// destination port 8080/tcp
+  toPorts: Listing<ToPort>?
+
+  /// Deprecated.
+  toRequires: Listing<String>(isEmpty)?
+
+  /// ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate
+  /// connections. Currently Cilium only supports toServices for K8s services.
+  toServices: Listing<EgressDenyToService>?
+}
+
+/// Authentication is the required authentication type for the allowed traffic, if any.
+class IngresAuthentication {
+  /// Mode is the required authentication mode for the allowed traffic, if any.
+  mode: "disabled"|"required"|"test-always-fail"
+}
+
+/// ICMPRule is a list of ICMP fields.
+class IngressDenyIcmp {
+  /// Fields is a list of ICMP fields.
+  fields: Listing<IcmpField>(length <= 40)?
+}
+
+/// ICMPField is a ICMP field.
+class IcmpField {
+  /// Family is a IP address version. Currently, we support `IPv4` and `IPv6`. `IPv4` is set as default.
+  ///
+  /// Default if undefined: `"IPv4"`
+  family: ("IPv4"|"IPv6")?
+
+  /// Type is a ICMP-type. It should be an 8bit code (0-255), or it's CamelCase name (for example,
+  /// "EchoReply"). Allowed ICMP types are: Ipv4: EchoReply | DestinationUnreachable | Redirect | Echo |
+  /// EchoRequest | RouterAdvertisement | RouterSelection | TimeExceeded | ParameterProblem | Timestamp |
+  /// TimestampReply | Photuris | ExtendedEcho Request | ExtendedEcho Reply Ipv6: DestinationUnreachable
+  /// | PacketTooBig | TimeExceeded | ParameterProblem | EchoRequest | EchoReply |
+  /// MulticastListenerQuery| MulticastListenerReport | MulticastListenerDone | RouterSolicitation |
+  /// RouterAdvertisement | NeighborSolicitation | NeighborAdvertisement | RedirectMessage |
+  /// RouterRenumbering | ICMPNodeInformationQuery | ICMPNodeInformationResponse |
+  /// InverseNeighborDiscoverySolicitation | InverseNeighborDiscoveryAdvertisement |
+  /// HomeAgentAddressDiscoveryRequest | HomeAgentAddressDiscoveryReply | MobilePrefixSolicitation |
+  /// MobilePrefixAdvertisement | DuplicateAddressRequestCodeSuffix |
+  /// DuplicateAddressConfirmationCodeSuffix | ExtendedEchoRequest | ExtendedEchoReply
+  type: Int|String
+}
+
+/// CIDRRule is a rule that specifies a CIDR prefix to/from which outside communication is allowed, along
+/// with an optional list of subnets within that CIDR prefix to/from which outside communication is not
+/// allowed.
+class IngressDenyFromCIDRSet {
+  /// CIDR is a CIDR prefix / IP Block.
+  cidr: String?
+
+  /// CIDRGroupRef is a reference to a CiliumCIDRGroup object. A CiliumCIDRGroup contains a list of CIDRs
+  /// that the endpoint, subject to the rule, can (Ingress/Egress) or cannot (IngressDeny/EgressDeny)
+  /// receive connections from.
+  cidrGroupRef: String(length <= 253, matches(Regex(#"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"#)))?
+
+  /// CIDRGroupSelector selects CiliumCIDRGroups by their labels, rather than by name.
+  cidrGroupSelector: FromCIDRSetCidrGroupSelector?
+
+  /// ExceptCIDRs is a list of IP blocks which the endpoint subject to the rule is not allowed to
+  /// initiate connections to. These CIDR prefixes should be contained within Cidr, using ExceptCIDRs
+  /// together with CIDRGroupRef is not supported yet. These exceptions are only applied to the Cidr in
+  /// this CIDRRule, and do not apply to any other CIDR prefixes in any other CIDRRules.
+  except: Listing<String>?
+}
+
+/// CIDRGroupSelector selects CiliumCIDRGroups by their labels, rather than by name.
+class FromCIDRSetCidrGroupSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class NodeSelectorMatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+class `FromCIDRSet[]Alternate0` {
+  cidr: Null
+}
+
+class `FromCIDRSet[]Alternate1` {
+  cidrGroupRef: Null
+}
+
+class `FromCIDRSet[]Alternate2` {
+  cidrGroupSelector: Null
+}
+
+/// EndpointSelector is a wrapper for k8s LabelSelector.
+class FromNode {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+class EgresToFQDN {
+  /// MatchName matches literal DNS names. A trailing "." is automatically added when missing.
+  matchName: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_]+[.]?)+$")))?
+
+  /// MatchPattern allows using wildcards to match DNS names. All wildcards are case insensitive. The
+  /// wildcards are: - "*" matches 0 or more DNS valid characters, and may occur anywhere in the pattern.
+  /// As a special case a "*" as the leftmost character, without a following "." matches all subdomains
+  /// as well as the name to the right. A trailing "." is automatically added when missing. - "**." is a
+  /// special prefix which matches all multilevel subdomains in the prefix.
+  ///
+  /// Examples: 1. `*.cilium.io` matches subdomains of cilium at that level www.cilium.io and
+  /// blog.cilium.io match, cilium.io and google.com do not 2. `*cilium.io` matches cilium.io and all
+  /// subdomains ends with "cilium.io" except those containing "." separator, subcilium.io and
+  /// sub-cilium.io match, www.cilium.io and blog.cilium.io does not 3. `sub*.cilium.io` matches
+  /// subdomains of cilium where the subdomain component begins with "sub". sub.cilium.io and
+  /// subdomain.cilium.io match while www.cilium.io, blog.cilium.io, cilium.io and google.com do not 4.
+  /// `**.cilium.io` matches all multilevel subdomains of cilium.io. "app.cilium.io" and
+  /// "test.app.cilium.io" match but not "cilium.io"
+  matchPattern: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))?
+}
+
+class `RulesDn[]Alternate0` {
+  matchName: Null
+}
+
+class `RulesDn[]Alternate1` {
+  matchPattern: Null
+}
+
+/// Groups structure to store all kinds of new integrations that needs a new derivative policy.
+class IngressDenyFromGroup {
+  /// AWSGroup is an structure that can be used to whitelisting information from AWS integration
+  aws: FromGroupAws?
+}
+
+/// AWSGroup is an structure that can be used to whitelisting information from AWS integration
+class FromGroupAws {
+  labels: Mapping<String, String>?
+
+  region: String?
+
+  securityGroupsIds: Listing<String>?
+
+  securityGroupsNames: Listing<String>?
+}
+
+/// PortRule is a list of ports/protocol combinations with optional Layer 7 rules which must be met.
+class ToPort {
+  /// listener specifies the name of a custom Envoy listener to which this traffic should be redirected
+  /// to.
+  listener: ToPortListener?
+
+  /// OriginatingTLS is the TLS context for the connections originated by the L7 proxy. For egress policy
+  /// this specifies the client-side TLS parameters for the upstream connection originating from the L7
+  /// proxy to the remote destination. For ingress policy this specifies the client-side TLS parameters
+  /// for the connection from the L7 proxy to the local endpoint.
+  originatingTLS: ToPortOriginatingTLS?
+
+  /// Ports is a list of L4 port/protocol
+  ports: Listing<ToPortPort>(length <= 40)?
+
+  /// Rules is a list of additional port level rules which must be met in order for the PortRule to allow
+  /// the traffic. If omitted or empty, no layer 7 rules are enforced.
+  rules: ToPortRules?
+
+  /// ServerNames is a list of allowed TLS SNI values. If not empty, then TLS must be present and one of
+  /// the provided SNIs must be indicated in the TLS handshake.
+  serverNames: Listing<String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))>(!isEmpty)?
+
+  /// TerminatingTLS is the TLS context for the connection terminated by the L7 proxy. For egress policy
+  /// this specifies the server-side TLS parameters to be applied on the connections originated from the
+  /// local endpoint and terminated by the L7 proxy. For ingress policy this specifies the server-side
+  /// TLS parameters to be applied on the connections originated from a remote source and terminated by
+  /// the L7 proxy.
+  terminatingTLS: ToPortTerminatingTLS?
+}
+
+/// listener specifies the name of a custom Envoy listener to which this traffic should be redirected to.
+class ToPortListener {
+  /// EnvoyConfig is a reference to the CEC or CCEC resource in which the listener is defined.
+  envoyConfig: ListenerEnvoyConfig
+
+  /// Name is the name of the listener.
+  name: String(!isEmpty)
+
+  /// Priority for this Listener that is used when multiple rules would apply different listeners to a
+  /// policy map entry. Behavior of this is implementation dependent.
+  priority: Int(isBetween(1, 100))?
+}
+
+/// EnvoyConfig is a reference to the CEC or CCEC resource in which the listener is defined.
+class ListenerEnvoyConfig {
+  /// Kind is the resource type being referred to. Defaults to CiliumEnvoyConfig or
+  /// CiliumClusterwideEnvoyConfig for CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy,
+  /// respectively. The only case this is currently explicitly needed is when referring to a
+  /// CiliumClusterwideEnvoyConfig from CiliumNetworkPolicy, as using a namespaced listener from a
+  /// cluster scoped policy is not allowed.
+  kind: ("CiliumEnvoyConfig"|"CiliumClusterwideEnvoyConfig")?
+
+  /// Name is the resource name of the CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig where the
+  /// listener is defined in.
+  name: String(!isEmpty)
+}
+
+/// OriginatingTLS is the TLS context for the connections originated by the L7 proxy. For egress policy
+/// this specifies the client-side TLS parameters for the upstream connection originating from the L7
+/// proxy to the remote destination. For ingress policy this specifies the client-side TLS parameters for
+/// the connection from the L7 proxy to the local endpoint.
+class ToPortOriginatingTLS {
+  /// Certificate is the file name or k8s secret item name for the certificate chain. If omitted,
+  /// 'tls.crt' is assumed, if it exists. If given, the item must exist.
+  certificate: String?
+
+  /// PrivateKey is the file name or k8s secret item name for the private key matching the certificate
+  /// chain. If omitted, 'tls.key' is assumed, if it exists. If given, the item must exist.
+  privateKey: String?
+
+  /// Secret is the secret that contains the certificates and private key for the TLS context. By
+  /// default, Cilium will search in this secret for the following items: - 'ca.crt' - Which represents
+  /// the trusted CA to verify remote source. - 'tls.crt' - Which represents the public key certificate.
+  /// - 'tls.key' - Which represents the private key matching the public key certificate.
+  secret: TerminatingTLSSecret
+
+  /// TrustedCA is the file name or k8s secret item name for the trusted CA. If omitted, 'ca.crt' is
+  /// assumed, if it exists. If given, the item must exist.
+  trustedCA: String?
+}
+
+/// Secret is the secret that contains the certificates and private key for the TLS context. By default,
+/// Cilium will search in this secret for the following items: - 'ca.crt' - Which represents the trusted
+/// CA to verify remote source. - 'tls.crt' - Which represents the public key certificate. - 'tls.key' -
+/// Which represents the private key matching the public key certificate.
+class TerminatingTLSSecret {
+  /// Name is the name of the secret.
+  name: String
+
+  /// Namespace is the namespace in which the secret exists. Context of use determines the default value
+  /// if left out (e.g., "default").
+  namespace: String?
+}
+
+/// PortProtocol specifies an L4 port with an optional transport protocol
+class ToPortPort {
+  /// EndPort can only be an L4 port number.
+  endPort: UInt16?
+
+  /// Port can be an L4 port number, or a name in the form of "http" or "http-8080".
+  port: String(matches(Regex("^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$")))?
+
+  /// Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols with transport ports (TCP,
+  /// UDP, SCTP) match.
+  ///
+  /// Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP", "IPV6", "ESP", "AH", "ANY"
+  ///
+  /// Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other extended IP protocols (VRRP,
+  /// IGMP) require the --enable-extended-ip-protocols flag to be set. These protocols do not use
+  /// transport-layer ports.
+  ///
+  /// Matching on ICMP is not supported.
+  ///
+  /// Named port specified for a container may narrow this down, but may not contradict this.
+  protocol: ("TCP"|"UDP"|"SCTP"|"VRRP"|"IGMP"|"GRE"|"IPIP"|"IPV6"|"ESP"|"AH"|"ANY")?
+}
+
+/// Rules is a list of additional port level rules which must be met in order for the PortRule to allow
+/// the traffic. If omitted or empty, no layer 7 rules are enforced.
+class ToPortRules {
+  /// DNS-specific rules.
+  dns: Listing<RulesDn>?
+
+  /// HTTP specific rules.
+  http: Listing<RulesHttp>?
+
+  /// Kafka-specific rules. Deprecated: This beta feature is deprecated and will be removed in a future
+  /// release.
+  kafka: Listing<RulesKafka>?
+
+  /// Key-value pair rules.
+  l7: Listing<Mapping<String, String>>?
+
+  /// Name of the L7 protocol for which the Key-value pair rules apply.
+  l7proto: String?
+}
+
+/// PortRuleDNS is a list of allowed DNS lookups.
+class RulesDn {
+  /// MatchName matches literal DNS names. A trailing "." is automatically added when missing.
+  matchName: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_]+[.]?)+$")))?
+
+  /// MatchPattern allows using wildcards to match DNS names. All wildcards are case insensitive. The
+  /// wildcards are: - "*" matches 0 or more DNS valid characters, and may occur anywhere in the pattern.
+  /// As a special case a "*" as the leftmost character, without a following "." matches all subdomains
+  /// as well as the name to the right. A trailing "." is automatically added when missing. - "**." is a
+  /// special prefix which matches all multilevel subdomains in the prefix.
+  ///
+  /// Examples: 1. `*.cilium.io` matches subdomains of cilium at that level www.cilium.io and
+  /// blog.cilium.io match, cilium.io and google.com do not 2. `*cilium.io` matches cilium.io and all
+  /// subdomains ends with "cilium.io" except those containing "." separator, subcilium.io and
+  /// sub-cilium.io match, www.cilium.io and blog.cilium.io does not 3. `sub*.cilium.io` matches
+  /// subdomains of cilium where the subdomain component begins with "sub". sub.cilium.io and
+  /// subdomain.cilium.io match while www.cilium.io, blog.cilium.io, cilium.io and google.com do not 4.
+  /// `**.cilium.io` matches all multilevel subdomains of cilium.io. "app.cilium.io" and
+  /// "test.app.cilium.io" match but not "cilium.io"
+  matchPattern: String(length <= 255, matches(Regex("^([-a-zA-Z0-9_*]+[.]?)+$")))?
+}
+
+/// PortRuleHTTP is a list of HTTP protocol constraints. All fields are optional, if all fields are empty
+/// or missing, the rule does not have any effect.
+///
+/// All fields of this type are extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the
+/// egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it
+/// can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+class RulesHttp {
+  /// HeaderMatches is a list of HTTP headers which must be present and match against the given values.
+  /// Mismatch field can be used to specify what to do when there is no match.
+  headerMatches: Listing<HttpHeaderMatch>?
+
+  /// Headers is a list of HTTP headers which must be present in the request. If omitted or empty,
+  /// requests are allowed regardless of headers present.
+  headers: Listing<String>?
+
+  /// Host is an extended POSIX regex matched against the host header of a request. Examples:
+  ///
+  /// - foo.bar.com will match the host fooXbar.com or foo-bar.com - foo\.bar\.com will only match the
+  /// host foo.bar.com
+  ///
+  /// If omitted or empty, the value of the host header is ignored.
+  host: String?
+
+  /// Method is an extended POSIX regex matched against the method of a request, e.g. "GET", "POST",
+  /// "PUT", "PATCH", "DELETE", ...
+  ///
+  /// If omitted or empty, all methods are allowed.
+  method: String?
+
+  /// Path is an extended POSIX regex matched against the path of a request. Currently it can contain
+  /// characters disallowed from the conventional "path" part of a URL as defined by RFC 3986.
+  ///
+  /// If omitted or empty, all paths are all allowed.
+  path: String?
+}
+
+/// HeaderMatch extends the HeaderValue for matching requirement of a named header field against an
+/// immediate string or a secret value. If none of the optional fields is present, then the header value
+/// is not matched, only presence of the header is enough.
+class HttpHeaderMatch {
+  /// Mismatch identifies what to do in case there is no match. The default is to drop the request.
+  /// Otherwise the overall rule is still considered as matching, but the mismatches are logged in the
+  /// access log.
+  mismatch: ("LOG"|"ADD"|"DELETE"|"REPLACE")?
+
+  /// Name identifies the header.
+  name: String(!isEmpty)
+
+  /// Secret refers to a secret that contains the value to be matched against. The secret must only
+  /// contain one entry. If the referred secret does not exist, and there is no "Value" specified, the
+  /// match will fail.
+  secret: HttpHeaderMatchSecret?
+
+  /// Value matches the exact value of the header. Can be specified either alone or together with
+  /// "Secret"; will be used as the header value if the secret can not be found in the latter case.
+  value: String?
+}
+
+/// Secret refers to a secret that contains the value to be matched against. The secret must only contain
+/// one entry. If the referred secret does not exist, and there is no "Value" specified, the match will
+/// fail.
+class HttpHeaderMatchSecret {
+  /// Name is the name of the secret.
+  name: String
+
+  /// Namespace is the namespace in which the secret exists. Context of use determines the default value
+  /// if left out (e.g., "default").
+  namespace: String?
+}
+
+/// PortRule is a list of Kafka protocol constraints. All fields are optional, if all fields are empty or
+/// missing, the rule will match all Kafka messages.
+class RulesKafka {
+  /// APIKey is a case-insensitive string matched against the key of a request, e.g. "produce", "fetch",
+  /// "createtopic", "deletetopic", et al Reference: https://kafka.apache.org/protocol#protocol_api_keys
+  ///
+  /// If omitted or empty, and if Role is not specified, then all keys are allowed.
+  apiKey: String?
+
+  /// APIVersion is the version matched against the api version of the Kafka message. If set, it has to
+  /// be a string representing a positive integer.
+  ///
+  /// If omitted or empty, all versions are allowed.
+  apiVersion: String?
+
+  /// ClientID is the client identifier as provided in the request.
+  ///
+  /// From Kafka protocol documentation: This is a user supplied identifier for the client application.
+  /// The user can use any identifier they like and it will be used when logging errors, monitoring
+  /// aggregates, etc. For example, one might want to monitor not just the requests per second overall,
+  /// but the number coming from each client application (each of which could reside on multiple
+  /// servers). This id acts as a logical grouping across all requests from a particular client.
+  ///
+  /// If omitted or empty, all client identifiers are allowed.
+  clientID: String?
+
+  /// Role is a case-insensitive string and describes a group of API keys necessary to perform certain
+  /// higher-level Kafka operations such as "produce" or "consume". A Role automatically expands into all
+  /// APIKeys required to perform the specified higher-level operation.
+  ///
+  /// The following values are supported: - "produce": Allow producing to the topics specified in the
+  /// rule - "consume": Allow consuming from the topics specified in the rule
+  ///
+  /// This field is incompatible with the APIKey field, i.e APIKey and Role cannot both be specified in
+  /// the same rule.
+  ///
+  /// If omitted or empty, and if APIKey is not specified, then all keys are allowed.
+  role: ("produce"|"consume")?
+
+  /// Topic is the topic name contained in the message. If a Kafka request contains multiple topics, then
+  /// all topics must be allowed or the message will be rejected.
+  ///
+  /// This constraint is ignored if the matched request message type doesn't contain any topic. Maximum
+  /// size of Topic can be 249 characters as per recent Kafka spec and allowed characters are a-z, A-Z,
+  /// 0-9, -, . and _.
+  ///
+  /// Older Kafka versions had longer topic lengths of 255, but in Kafka 0.10 version the length was
+  /// changed from 255 to 249. For compatibility reasons we are using 255.
+  ///
+  /// If omitted or empty, all topics are allowed.
+  topic: String(length <= 255)?
+}
+
+class RulesRulesAlternate0 {
+  http: Null
+}
+
+class RulesRulesAlternate1 {
+  kafka: Null
+}
+
+class RulesRulesAlternate2 {
+  dns: Null
+}
+
+class RulesRulesAlternate3 {
+  l7proto: Null
+}
+
+/// TerminatingTLS is the TLS context for the connection terminated by the L7 proxy. For egress policy
+/// this specifies the server-side TLS parameters to be applied on the connections originated from the
+/// local endpoint and terminated by the L7 proxy. For ingress policy this specifies the server-side TLS
+/// parameters to be applied on the connections originated from a remote source and terminated by the L7
+/// proxy.
+class ToPortTerminatingTLS {
+  /// Certificate is the file name or k8s secret item name for the certificate chain. If omitted,
+  /// 'tls.crt' is assumed, if it exists. If given, the item must exist.
+  certificate: String?
+
+  /// PrivateKey is the file name or k8s secret item name for the private key matching the certificate
+  /// chain. If omitted, 'tls.key' is assumed, if it exists. If given, the item must exist.
+  privateKey: String?
+
+  /// Secret is the secret that contains the certificates and private key for the TLS context. By
+  /// default, Cilium will search in this secret for the following items: - 'ca.crt' - Which represents
+  /// the trusted CA to verify remote source. - 'tls.crt' - Which represents the public key certificate.
+  /// - 'tls.key' - Which represents the private key matching the public key certificate.
+  secret: TerminatingTLSSecret
+
+  /// TrustedCA is the file name or k8s secret item name for the trusted CA. If omitted, 'ca.crt' is
+  /// assumed, if it exists. If given, the item must exist.
+  trustedCA: String?
+}
+
+/// Service selects policy targets that are bundled as part of a logical load-balanced service.
+///
+/// Currently only Kubernetes-based Services are supported.
+class EgressDenyToService {
+  /// K8sService selects service by name and namespace pair
+  k8sService: ToServiceK8sService?
+
+  /// K8sServiceSelector selects services by k8s labels and namespace
+  k8sServiceSelector: ToServiceK8sServiceSelector?
+}
+
+/// K8sService selects service by name and namespace pair
+class ToServiceK8sService {
+  namespace: String?
+
+  serviceName: String?
+}
+
+/// K8sServiceSelector selects services by k8s labels and namespace
+class ToServiceK8sServiceSelector {
+  namespace: String?
+
+  /// ServiceSelector is a label selector for k8s services
+  selector: K8sServiceSelectorSelector
+}
+
+/// ServiceSelector is a label selector for k8s services
+class K8sServiceSelectorSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// EgressDenyRule contains all rule types which can be applied at egress, i.e. network traffic that
+/// originates inside the endpoint and exits the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members of the structure are specified, then all members must match in order for the
+/// rule to take effect.
+///
+/// - ToEndpoints, ToCIDR, ToCIDRSet, ToEntities, ToServices and ToGroups are mutually exclusive. Only
+/// one of these members may be present within an individual rule.
+class SpecEgressDeny {
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// not allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" is not allowed to initiate type 8 ICMP
+  /// connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections. Only connections destined for outside of the cluster and not targeting the host will
+  /// be subject to CIDR rules. This will match on the destination IP address of outgoing connections.
+  /// Adding a prefix into ToCIDR or into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are
+  /// allowed between ToCIDR and ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24
+  toCIDR: Listing<String>?
+
+  /// ToCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to initiate
+  /// connections to in addition to connections which are allowed via ToEndpoints, along with a list of
+  /// subnets contained within their corresponding IP block to which traffic should not be allowed. This
+  /// will match on the destination IP address of outgoing connections. Adding a prefix into ToCIDR or
+  /// into ToCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between ToCIDR and
+  /// ToCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=database-proxy" is allowed to initiate connections to
+  /// 10.2.3.0/24 except from IPs in subnet 10.2.3.0/28.
+  toCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// ToEndpoints is a list of endpoints identified by an EndpointSelector to which the endpoints subject
+  /// to the rule are allowed to communicate.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" can communicate with any endpoint carrying the
+  /// label "role=backend".
+  ///
+  /// Note that while an empty non-nil ToEndpoints does not select anything, nil ToEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  toEndpoints: Listing<FromNode>?
+
+  /// ToEntities is a list of special entities to which the endpoint subject to the rule is allowed to
+  /// initiate connections. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  toEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// ToGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: toGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  toGroups: Listing<IngressDenyFromGroup>?
+
+  /// ToNodes is a list of nodes identified by an EndpointSelector to which endpoints subject to the rule
+  /// is allowed to communicate.
+  toNodes: Listing<FromNode>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is not allowed to connect to.
+  ///
+  /// Example: Any endpoint with the label "role=frontend" is not allowed to initiate connections to
+  /// destination port 8080/tcp
+  toPorts: Listing<IngressDenyToPort>?
+
+  /// Deprecated.
+  toRequires: Listing<String>(isEmpty)?
+
+  /// ToServices is a list of services to which the endpoint subject to the rule is allowed to initiate
+  /// connections. Currently Cilium only supports toServices for K8s services.
+  toServices: Listing<EgressDenyToService>?
+}
+
+/// PortDenyRule is a list of ports/protocol that should be used for deny policies. This structure lacks
+/// the L7Rules since it's not supported in deny policies.
+class IngressDenyToPort {
+  /// Ports is a list of L4 port/protocol
+  ports: Listing<ToPortPort>?
+}
+
+/// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a default
+/// deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy to be
+/// dropped.
+///
+/// If not specified, the default is true for each traffic direction that has rules, and false otherwise.
+/// For example, if a policy only has Ingress or IngressDeny rules, then the default for ingress is true
+/// and egress is false.
+///
+/// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any policy
+/// requests it.
+///
+/// This is useful for creating broad-based network policies that will not cause endpoints to enter
+/// default-deny mode.
+class SpecEnableDefaultDeny {
+  /// Whether or not the endpoint should have a default-deny rule applied to egress traffic.
+  egress: Boolean?
+
+  /// Whether or not the endpoint should have a default-deny rule applied to ingress traffic.
+  ingress: Boolean?
+}
+
+/// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+/// NodeSelector cannot be both empty and are mutually exclusive.
+class SpecEndpointSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// IngressRule contains all rule types which can be applied at ingress, i.e. network traffic that
+/// originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members are set, all of them need to match in order for the rule to take effect.
+///
+/// - FromEndpoints, FromCIDR, FromCIDRSet and FromEntities are mutually exclusive. Only one of these
+/// members may be present within an individual rule.
+class SpecIngres {
+  /// Authentication is the required authentication type for the allowed traffic, if any.
+  authentication: IngresAuthentication?
+
+  /// FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from. Only connections which do *not* originate from the cluster or from the local host
+  /// are subject to CIDR rules. In order to allow in-cluster connectivity, use the FromEndpoints field.
+  /// This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or
+  /// into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and
+  /// FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.3.9.1
+  fromCIDR: Listing<String>?
+
+  /// FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from in addition to FromEndpoints, along with a list of subnets contained within their
+  /// corresponding IP block from which traffic should not be allowed. This will match on the source IP
+  /// address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no
+  /// ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+  fromCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to
+  /// communicate with the endpoint subject to the rule.
+  ///
+  /// Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the
+  /// label "role=frontend".
+  ///
+  /// Note that while an empty non-nil FromEndpoints does not select anything, nil FromEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  fromEndpoints: Listing<FromNode>?
+
+  /// FromEntities is a list of special entities which the endpoint subject to the rule is allowed to
+  /// receive connections from. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  fromEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// FromGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: FromGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  fromGroups: Listing<IngressDenyFromGroup>?
+
+  /// FromNodes is a list of nodes identified by an EndpointSelector which are allowed to communicate
+  /// with the endpoint subject to the rule.
+  fromNodes: Listing<FromNode>?
+
+  /// Deprecated.
+  fromRequires: Listing<String>(isEmpty)?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can only accept incoming type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can only accept incoming connections on port
+  /// 80/tcp.
+  toPorts: Listing<ToPort>?
+}
+
+/// IngressDenyRule contains all rule types which can be applied at ingress, i.e. network traffic that
+/// originates outside of the endpoint and is entering the endpoint selected by the endpointSelector.
+///
+/// - All members of this structure are optional. If omitted or empty, the member will have no effect on
+/// the rule.
+///
+/// - If multiple members are set, all of them need to match in order for the rule to take effect.
+///
+/// - FromEndpoints, FromCIDR, FromCIDRSet, FromGroups and FromEntities are mutually exclusive. Only one
+/// of these members may be present within an individual rule.
+class SpecIngressDeny {
+  /// FromCIDR is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from. Only connections which do *not* originate from the cluster or from the local host
+  /// are subject to CIDR rules. In order to allow in-cluster connectivity, use the FromEndpoints field.
+  /// This will match on the source IP address of incoming connections. Adding a prefix into FromCIDR or
+  /// into FromCIDRSet with no ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and
+  /// FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.3.9.1
+  fromCIDR: Listing<String>?
+
+  /// FromCIDRSet is a list of IP blocks which the endpoint subject to the rule is allowed to receive
+  /// connections from in addition to FromEndpoints, along with a list of subnets contained within their
+  /// corresponding IP block from which traffic should not be allowed. This will match on the source IP
+  /// address of incoming connections. Adding a prefix into FromCIDR or into FromCIDRSet with no
+  /// ExcludeCIDRs is equivalent. Overlaps are allowed between FromCIDR and FromCIDRSet.
+  ///
+  /// Example: Any endpoint with the label "app=my-legacy-pet" is allowed to receive connections from
+  /// 10.0.0.0/8 except from IPs in subnet 10.96.0.0/12.
+  fromCIDRSet: Listing<IngressDenyFromCIDRSet>?
+
+  /// FromEndpoints is a list of endpoints identified by an EndpointSelector which are allowed to
+  /// communicate with the endpoint subject to the rule.
+  ///
+  /// Example: Any endpoint with the label "role=backend" can be consumed by any endpoint carrying the
+  /// label "role=frontend".
+  ///
+  /// Note that while an empty non-nil FromEndpoints does not select anything, nil FromEndpoints is
+  /// implicitly treated as a wildcard selector if ToPorts are also specified. To select everything, use
+  /// one EndpointSelector without any match requirements.
+  fromEndpoints: Listing<FromNode>?
+
+  /// FromEntities is a list of special entities which the endpoint subject to the rule is allowed to
+  /// receive connections from. Supported entities are `world`, `cluster`, `host`, `remote-node`,
+  /// `kube-apiserver`, `ingress`, `init`, `health`, `unmanaged`, `none` and `all`.
+  fromEntities: Listing<"all"|"world"|"cluster"|"host"|"init"|"ingress"|"unmanaged"|"remote-node"|"health"|"none"|"kube-apiserver">?
+
+  /// FromGroups is a directive that allows the integration with multiple outside providers. Currently,
+  /// only AWS is supported, and the rule can select by multiple sub directives:
+  ///
+  /// Example: FromGroups: - aws: securityGroupsIds: - 'sg-XXXXXXXXXXXXX'
+  fromGroups: Listing<IngressDenyFromGroup>?
+
+  /// FromNodes is a list of nodes identified by an EndpointSelector which are allowed to communicate
+  /// with the endpoint subject to the rule.
+  fromNodes: Listing<FromNode>?
+
+  /// Deprecated.
+  fromRequires: Listing<String>(isEmpty)?
+
+  /// ICMPs is a list of ICMP rule identified by type number which the endpoint subject to the rule is
+  /// not allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can not accept incoming type 8 ICMP connections.
+  icmps: Listing<IngressDenyIcmp>?
+
+  /// ToPorts is a list of destination ports identified by port number and protocol which the endpoint
+  /// subject to the rule is not allowed to receive connections on.
+  ///
+  /// Example: Any endpoint with the label "app=httpd" can not accept incoming connections on port
+  /// 80/tcp.
+  toPorts: Listing<IngressDenyToPort>?
+}
+
+/// Label is the Cilium's representation of a container label.
+class SpecLabel {
+  key: String
+
+  /// Source can be one of the above values (e.g.: LabelSourceContainer).
+  source: String?
+
+  value: String?
+}
+
+/// Log specifies custom policy-specific Hubble logging configuration.
+class SpecLog {
+  /// Value is a free-form string that is included in Hubble flows that match this policy. The string is
+  /// limited to 32 printable characters.
+  value: String(length <= 32, matches(Regex(#"^\PC*$"#)))?
+}
+
+/// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+/// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+/// CiliumClusterwideNetworkPolicies.
+class SpecNodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<NodeSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+class `[]Alternate0` {
+  ingress: Null
+}
+
+class `[]Alternate1` {
+  ingressDeny: Null
+}
+
+class `[]Alternate2` {
+  egress: Null
+}
+
+class `[]Alternate3` {
+  egressDeny: Null
+}
+
+/// Rule is a policy rule which must be applied to all endpoints which match the labels contained in the
+/// endpointSelector
+///
+/// Each rule is split into an ingress section which contains all rules applicable at ingress, and an
+/// egress section applicable at egress. For rule types such as `L4Rule` and `CIDR` which can be applied
+/// at both ingress and egress, both ingress and egress side have to either specifically allow the
+/// connection or one side has to be omitted.
+///
+/// Either ingress, egress, or both can be provided. If both ingress and egress are omitted, the rule has
+/// no effect.
+class ItemSpec {
+  /// Description is a free form string, it can be used by the creator of the rule to store human
+  /// readable explanation of the purpose of this rule. Rules cannot be identified by comment.
+  description: String?
+
+  /// Egress is a list of EgressRule which are enforced at egress. If omitted or empty, this rule does
+  /// not apply at egress.
+  egress: Listing<SpecEgres>?
+
+  /// EgressDeny is a list of EgressDenyRule which are enforced at egress. Any rule inserted here will be
+  /// denied regardless of the allowed egress rules in the 'egress' field. If omitted or empty, this rule
+  /// does not apply at egress.
+  egressDeny: Listing<SpecEgressDeny>?
+
+  /// EnableDefaultDeny determines whether this policy configures the subject endpoint(s) to have a
+  /// default deny mode. If enabled, this causes all traffic not explicitly allowed by a network policy
+  /// to be dropped.
+  ///
+  /// If not specified, the default is true for each traffic direction that has rules, and false
+  /// otherwise. For example, if a policy only has Ingress or IngressDeny rules, then the default for
+  /// ingress is true and egress is false.
+  ///
+  /// If multiple policies apply to an endpoint, that endpoint's default deny will be enabled if any
+  /// policy requests it.
+  ///
+  /// This is useful for creating broad-based network policies that will not cause endpoints to enter
+  /// default-deny mode.
+  enableDefaultDeny: SpecEnableDefaultDeny?
+
+  /// EndpointSelector selects all endpoints which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive.
+  endpointSelector: SpecEndpointSelector?
+
+  /// Ingress is a list of IngressRule which are enforced at ingress. If omitted or empty, this rule does
+  /// not apply at ingress.
+  ingress: Listing<SpecIngres>?
+
+  /// IngressDeny is a list of IngressDenyRule which are enforced at ingress. Any rule inserted here will
+  /// be denied regardless of the allowed ingress rules in the 'ingress' field. If omitted or empty, this
+  /// rule does not apply at ingress.
+  ingressDeny: Listing<SpecIngressDeny>?
+
+  /// Labels is a list of optional strings which can be used to re-identify the rule or to store
+  /// metadata. It is possible to lookup or delete strings based on labels. Labels are not required to be
+  /// unique, multiple rules can have overlapping or identical labels.
+  labels: Listing<SpecLabel>?
+
+  /// Log specifies custom policy-specific Hubble logging configuration.
+  log: SpecLog?
+
+  /// NodeSelector selects all nodes which should be subject to this rule. EndpointSelector and
+  /// NodeSelector cannot be both empty and are mutually exclusive. Can only be used in
+  /// CiliumClusterwideNetworkPolicies.
+  nodeSelector: SpecNodeSelector?
+}
+
+/// Status is the status of the Cilium policy rule
+class Status {
+  conditions: Listing<Condition>?
+
+  /// DerivativePolicies is the status of all policies derived from the Cilium policy
+  derivativePolicies: Mapping<String, DerivativePolicies>?
+}
+
+class Condition {
+  /// The last time the condition transitioned from one status to another.
+  lastTransitionTime: String?
+
+  /// A human readable message indicating details about the transition.
+  message: String?
+
+  /// The reason for the condition's last transition.
+  reason: String?
+
+  /// The status of the condition, one of True, False, or Unknown
+  status: String
+
+  /// The type of the policy condition
+  type: String
+}
+
+/// CiliumNetworkPolicyNodeStatus is the status of a Cilium policy rule for a specific node.
+class DerivativePolicies {
+  /// Annotations corresponds to the Annotations in the ObjectMeta of the CNP that have been realized on
+  /// the node for CNP. That is, if a CNP has been imported and has been assigned annotation X=Y by the
+  /// user, Annotations in CiliumNetworkPolicyNodeStatus will be X=Y once the CNP that was imported
+  /// corresponding to Annotation X=Y has been realized on the node.
+  annotations: Mapping<String, String>?
+
+  /// Enforcing is set to true once all endpoints present at the time the policy has been imported are
+  /// enforcing this policy.
+  enforcing: Boolean?
+
+  /// Error describes any error that occurred when parsing or importing the policy, or realizing the
+  /// policy for the endpoints to which it applies on the node.
+  error: String?
+
+  /// LastUpdated contains the last time this status was updated
+  lastUpdated: String?
+
+  /// Revision is the policy revision of the repository which first implemented this policy.
+  localPolicyRevision: Int?
+
+  /// OK is true when the policy has been parsed and imported successfully into the in-memory policy
+  /// repository on the node.
+  ok: Boolean?
+}

--- a/packages/io.cilium/v2/CiliumNode.pkl
+++ b/packages/io.cilium/v2/CiliumNode.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumNode represents a node managed by Cilium. It contains a specification to control various node
 /// specific configuration aspects and a status section to represent the status of the node.
 ///

--- a/packages/io.cilium/v2/CiliumNode.pkl
+++ b/packages/io.cilium/v2/CiliumNode.pkl
@@ -1,0 +1,568 @@
+/// CiliumNode represents a node managed by Cilium. It contains a specification to control various node
+/// specific configuration aspects and a status section to represent the status of the node.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml>.
+module io.cilium.v2.CiliumNode
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumNode"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec defines the desired specification/configuration of the node.
+spec: Spec
+
+/// Status defines the realized specification/configuration and status of the node.
+status: Status?
+
+/// Spec defines the desired specification/configuration of the node.
+class Spec {
+  /// Addresses is the list of all node addresses.
+  addresses: Listing<Address>?
+
+  /// AlibabaCloud is the AlibabaCloud IPAM specific configuration.
+  `alibaba-cloud`: AlibabaCloud?
+
+  /// Azure is the Azure IPAM specific configuration.
+  azure: Azure?
+
+  /// BootID is a unique node identifier generated on boot
+  bootid: String?
+
+  /// Encryption is the encryption configuration of the node.
+  encryption: Encryption?
+
+  /// ENI is the AWS ENI specific configuration.
+  eni: Eni?
+
+  /// HealthAddressing is the addressing information for health connectivity checking.
+  health: Health?
+
+  /// IngressAddressing is the addressing information for Ingress listener.
+  ingress: Ingress?
+
+  /// InstanceID is the identifier of the node. This is different from the node name which is typically
+  /// the FQDN of the node. The InstanceID typically refers to the identifier used by the cloud provider
+  /// or some other means of identification.
+  `instance-id`: String?
+
+  /// IPAM is the address management specification. This section can be populated by a user or it can be
+  /// automatically populated by an IPAM operator.
+  ipam: Ipam?
+
+  /// NodeIdentity is the Cilium numeric identity allocated for the node, if any.
+  nodeidentity: Int?
+}
+
+/// NodeAddress is a node address.
+class Address {
+  /// IP is an IP of a node
+  ip: String?
+
+  /// Type is the type of the node address
+  type: String?
+}
+
+/// AlibabaCloud is the AlibabaCloud IPAM specific configuration.
+class AlibabaCloud {
+  /// AvailabilityZone is the availability zone to use when allocating ENIs.
+  `availability-zone`: String?
+
+  /// CIDRBlock is vpc ipv4 CIDR
+  `cidr-block`: String?
+
+  /// InstanceType is the ECS instance type, e.g. "ecs.g6.2xlarge"
+  `instance-type`: String?
+
+  /// SecurityGroupTags is the list of tags to use when evaluating which security groups to use for the
+  /// ENI.
+  `security-group-tags`: Mapping<String, String>?
+
+  /// SecurityGroups is the list of security groups to attach to any ENI that is created and attached to
+  /// the instance.
+  `security-groups`: Listing<String>?
+
+  /// VPCID is the VPC ID to use when allocating ENIs.
+  `vpc-id`: String?
+
+  /// VSwitchTags is the list of tags to use when evaluating which vSwitch to use for the ENI.
+  `vswitch-tags`: Mapping<String, String>?
+
+  /// VSwitches is the ID of vSwitch available for ENI
+  vswitches: Listing<String>?
+}
+
+/// Azure is the Azure IPAM specific configuration.
+class Azure {
+  /// InterfaceName is the name of the interface the cilium-operator will use to allocate all the IPs on
+  `interface-name`: String?
+}
+
+/// Encryption is the encryption configuration of the node.
+class Encryption {
+  /// Key is the index to the key to use for encryption or 0 if encryption is disabled.
+  key: Int?
+}
+
+/// ENI is the AWS ENI specific configuration.
+class Eni {
+  /// AvailabilityZone is the availability zone to use when allocating ENIs.
+  `availability-zone`: String?
+
+  /// DeleteOnTermination defines that the ENI should be deleted when the associated instance is
+  /// terminated. If the parameter is not set the default behavior is to delete the ENI on instance
+  /// termination.
+  `delete-on-termination`: Boolean?
+
+  /// DisablePrefixDelegation determines whether ENI prefix delegation should be disabled on this node.
+  `disable-prefix-delegation`: Boolean?
+
+  /// ExcludeInterfaceTags is the list of tags to use when excluding ENIs for Cilium IP allocation. Any
+  /// interface matching this set of tags will not be managed by Cilium.
+  `exclude-interface-tags`: Mapping<String, String>?
+
+  /// FirstInterfaceIndex is the index of the first ENI to use for IP allocation, e.g. if the node has
+  /// eth0, eth1, eth2 and FirstInterfaceIndex is set to 1, then only eth1 and eth2 will be used for IP
+  /// allocation, eth0 will be ignored for PodIP allocation.
+  `first-interface-index`: Int(isPositive)?
+
+  /// InstanceID is the AWS InstanceId of the node. The InstanceID is used to retrieve AWS metadata for
+  /// the node.
+  ///
+  /// OBSOLETE: This field is obsolete, please use Spec.InstanceID
+  `instance-id`: String?
+
+  /// InstanceType is the AWS EC2 instance type, e.g. "m5.large"
+  `instance-type`: String?
+
+  /// MaxAboveWatermark is the maximum number of addresses to allocate beyond the addresses needed to
+  /// reach the PreAllocate watermark. Going above the watermark can help reduce the number of API calls
+  /// to allocate IPs, e.g. when a new ENI is allocated, as many secondary IPs as possible are allocated.
+  /// Limiting the amount can help reduce waste of IPs.
+  ///
+  /// OBSOLETE: This field is obsolete, please use Spec.IPAM.MaxAboveWatermark
+  `max-above-watermark`: Int(isPositive)?
+
+  /// MinAllocate is the minimum number of IPs that must be allocated when the node is first
+  /// bootstrapped. It defines the minimum base socket of addresses that must be available. After
+  /// reaching this watermark, the PreAllocate and MaxAboveWatermark logic takes over to continue
+  /// allocating IPs.
+  ///
+  /// OBSOLETE: This field is obsolete, please use Spec.IPAM.MinAllocate
+  `min-allocate`: Int(isPositive)?
+
+  /// NodeSubnetID is the subnet of the primary ENI the instance was brought up with. It is used as a
+  /// sensible default subnet to create ENIs in.
+  `node-subnet-id`: String?
+
+  /// PreAllocate defines the number of IP addresses that must be available for allocation in the
+  /// IPAMspec. It defines the buffer of addresses available immediately without requiring
+  /// cilium-operator to get involved.
+  ///
+  /// OBSOLETE: This field is obsolete, please use Spec.IPAM.PreAllocate
+  `pre-allocate`: Int(isPositive)?
+
+  /// SecurityGroupTags is the list of tags to use when evaliating what AWS security groups to use for
+  /// the ENI.
+  `security-group-tags`: Mapping<String, String>?
+
+  /// SecurityGroups is the list of security groups to attach to any ENI that is created and attached to
+  /// the instance.
+  `security-groups`: Listing<String>?
+
+  /// SubnetIDs is the list of subnet ids to use when evaluating what AWS subnets to use for ENI and IP
+  /// allocation.
+  `subnet-ids`: Listing<String>?
+
+  /// SubnetTags is the list of tags to use when evaluating what AWS subnets to use for ENI and IP
+  /// allocation.
+  `subnet-tags`: Mapping<String, String>?
+
+  /// UsePrimaryAddress determines whether an ENI's primary address should be available for allocations
+  /// on the node
+  `use-primary-address`: Boolean?
+
+  /// VpcID is the VPC ID to use when allocating ENIs.
+  `vpc-id`: String?
+}
+
+/// HealthAddressing is the addressing information for health connectivity checking.
+class Health {
+  /// IPv4 is the IPv4 address of the IPv4 health endpoint.
+  ipv4: String?
+
+  /// IPv6 is the IPv6 address of the IPv4 health endpoint.
+  ipv6: String?
+}
+
+/// IngressAddressing is the addressing information for Ingress listener.
+class Ingress {
+  ipv4: String?
+
+  ipv6: String?
+}
+
+/// IPAM is the address management specification. This section can be populated by a user or it can be
+/// automatically populated by an IPAM operator.
+class Ipam {
+  /// IPv6Pool is the list of IPv6 addresses available to the node for allocation. When an IPv6 address
+  /// is used, it will remain on this list but will be added to Status.IPAM.IPv6Used
+  `ipv6-pool`: Mapping<String, Used>?
+
+  /// MaxAboveWatermark is the maximum number of addresses to allocate beyond the addresses needed to
+  /// reach the PreAllocate watermark. Going above the watermark can help reduce the number of API calls
+  /// to allocate IPs, e.g. when a new ENI is allocated, as many secondary IPs as possible are allocated.
+  /// Limiting the amount can help reduce waste of IPs.
+  `max-above-watermark`: Int(isPositive)?
+
+  /// MaxAllocate is the maximum number of IPs that can be allocated to the node. When the current amount
+  /// of allocated IPs will approach this value, the considered value for PreAllocate will decrease down
+  /// to 0 in order to not attempt to allocate more addresses than defined.
+  `max-allocate`: Int(isPositive)?
+
+  /// MinAllocate is the minimum number of IPs that must be allocated when the node is first
+  /// bootstrapped. It defines the minimum base socket of addresses that must be available. After
+  /// reaching this watermark, the PreAllocate and MaxAboveWatermark logic takes over to continue
+  /// allocating IPs.
+  `min-allocate`: Int(isPositive)?
+
+  /// PodCIDRs is the list of CIDRs available to the node for allocation. When an IP is used, the IP will
+  /// be added to Status.IPAM.Used
+  podCIDRs: Listing<String>?
+
+  /// Pool is the list of IPv4 addresses available to the node for allocation. When an IPv4 address is
+  /// used, it will remain on this list but will be added to Status.IPAM.Used
+  pool: Mapping<String, Used>?
+
+  /// Pools contains the list of assigned IPAM pools for this node.
+  pools: Pools?
+
+  /// PreAllocate defines the number of IP addresses that must be available for allocation in the
+  /// IPAMspec. It defines the buffer of addresses available immediately without requiring
+  /// cilium-operator to get involved.
+  `pre-allocate`: Int(isPositive)?
+
+  /// StaticIPTags are used to determine the pool of IPs from which to attribute a static IP to the node.
+  /// For example in AWS this is used to filter Elastic IP Addresses.
+  `static-ip-tags`: Mapping<String, String>?
+}
+
+/// AllocationIP is an IP which is available for allocation, or already has been allocated
+class Used {
+  /// Owner is the owner of the IP. This field is set if the IP has been allocated. It will be set to the
+  /// pod name or another identifier representing the usage of the IP
+  ///
+  /// The owner field is left blank for an entry in Spec.IPAM.Pool and filled out as the IP is used and
+  /// also added to Status.IPAM.Used.
+  owner: String?
+
+  /// Resource is set for both available and allocated IPs, it represents what resource the IP is
+  /// associated with, e.g. in combination with AWS ENI, this will refer to the ID of the ENI
+  resource: String?
+}
+
+/// Pools contains the list of assigned IPAM pools for this node.
+class Pools {
+  /// Allocated contains the list of pooled CIDR assigned to this node. The operator will add new pod
+  /// CIDRs to this field, whereas the agent will remove CIDRs it has released.
+  allocated: Listing<Allocated>?
+
+  /// Requested contains a list of IPAM pool requests, i.e. indicates how many addresses this node
+  /// requests out of each pool listed here. This field is owned and written to by cilium-agent and read
+  /// by the operator.
+  requested: Listing<Requested>?
+}
+
+/// IPAMPoolAllocation describes an allocation of an IPAM pool from the operator to the node. It contains
+/// the assigned PodCIDRs allocated from this pool
+class Allocated {
+  /// CIDRs contains a list of pod CIDRs currently allocated from this pool
+  cidrs: Listing<String>?
+
+  /// Pool is the name of the IPAM pool backing this allocation
+  pool: String(!isEmpty)
+}
+
+class Requested {
+  /// Needed indicates how many IPs out of the above Pool this node requests from the operator. The
+  /// operator runs a reconciliation loop to ensure each node always has enough PodCIDRs allocated in
+  /// each pool to fulfill the requested number of IPs here.
+  needed: Needed?
+
+  /// Pool is the name of the IPAM pool backing this request
+  pool: String(!isEmpty)
+}
+
+/// Needed indicates how many IPs out of the above Pool this node requests from the operator. The
+/// operator runs a reconciliation loop to ensure each node always has enough PodCIDRs allocated in each
+/// pool to fulfill the requested number of IPs here.
+class Needed {
+  /// IPv4Addrs contains the number of requested IPv4 addresses out of a given pool
+  `ipv4-addrs`: Int?
+
+  /// IPv6Addrs contains the number of requested IPv6 addresses out of a given pool
+  `ipv6-addrs`: Int?
+}
+
+/// Status defines the realized specification/configuration and status of the node.
+class Status {
+  /// AlibabaCloud is the AlibabaCloud specific status of the node.
+  `alibaba-cloud`: StatusAlibabaCloud?
+
+  /// Azure is the Azure specific status of the node.
+  azure: StatusAzure?
+
+  /// ENI is the AWS ENI specific status of the node.
+  eni: StatusEni?
+
+  /// IPAM is the IPAM status of the node.
+  ipam: StatusIpam?
+}
+
+/// AlibabaCloud is the AlibabaCloud specific status of the node.
+class StatusAlibabaCloud {
+  /// ENIs is the list of ENIs on the node
+  enis: Mapping<String, Enis>?
+}
+
+/// ENI represents an AlibabaCloud Elastic Network Interface
+class Enis {
+  /// InstanceID is the InstanceID using this ENI
+  `instance-id`: String?
+
+  /// MACAddress is the mac address of the ENI
+  `mac-address`: String?
+
+  /// NetworkInterfaceID is the ENI id
+  `network-interface-id`: String?
+
+  /// PrimaryIPAddress is the primary IP on ENI
+  `primary-ip-address`: String?
+
+  /// PrivateIPSets is the list of all IPs on the ENI, including PrimaryIPAddress
+  `private-ipsets`: Listing<PrivateIpset>?
+
+  /// SecurityGroupIDs is the security group ids used by this ENI
+  `security-groupids`: Listing<String>?
+
+  /// Tags is the tags on this ENI
+  tags: Mapping<String, String>?
+
+  /// Type is the ENI type Primary or Secondary
+  type: String?
+
+  /// VPC is the vpc to which the ENI belongs
+  vpc: Vpc?
+
+  /// VSwitch is the vSwitch the ENI is using
+  vswitch: Vswitch?
+
+  /// ZoneID is the zone to which the ENI belongs
+  `zone-id`: String?
+}
+
+/// PrivateIPSet is a nested struct in ecs response
+class PrivateIpset {
+  primary: Boolean?
+
+  `private-ip-address`: String?
+}
+
+/// VPC is the vpc to which the ENI belongs
+class Vpc {
+  /// CIDRBlock is the VPC IPv4 CIDR
+  cidr: String?
+
+  /// IPv6CIDRBlock is the VPC IPv6 CIDR
+  `ipv6-cidr`: String?
+
+  /// SecondaryCIDRs is the list of Secondary CIDRs associated with the VPC
+  `secondary-cidrs`: Listing<String>?
+
+  /// VPCID is the vpc to which the ENI belongs
+  `vpc-id`: String?
+}
+
+/// VSwitch is the vSwitch the ENI is using
+class Vswitch {
+  /// CIDRBlock is the vSwitch IPv4 CIDR
+  cidr: String?
+
+  /// IPv6CIDRBlock is the vSwitch IPv6 CIDR
+  `ipv6-cidr`: String?
+
+  /// VSwitchID is the vSwitch to which the ENI belongs
+  `vswitch-id`: String?
+}
+
+/// Azure is the Azure specific status of the node.
+class StatusAzure {
+  /// Interfaces is the list of interfaces on the node
+  interfaces: Listing<Interface>?
+}
+
+/// AzureInterface represents an Azure Interface
+class Interface {
+  /// GatewayIP is the interface's subnet's default route
+  ///
+  /// OBSOLETE: This field is obsolete, please use Gateway field instead.
+  GatewayIP: String?
+
+  /// Addresses is the list of all IPs associated with the interface, including all secondary addresses
+  addresses: Listing<InterfaceAddress>?
+
+  /// CIDR is the range that the interface belongs to.
+  cidr: String?
+
+  /// Gateway is the interface's subnet's default route
+  gateway: String?
+
+  /// ID is the identifier
+  id: String?
+
+  /// MAC is the mac address
+  mac: String?
+
+  /// Name is the name of the interface
+  name: String?
+
+  /// SecurityGroup is the security group associated with the interface
+  `security-group`: String?
+
+  /// State is the provisioning state
+  state: String?
+}
+
+/// AzureAddress is an IP address assigned to an AzureInterface
+class InterfaceAddress {
+  /// IP is the ip address of the address
+  ip: String?
+
+  /// State is the provisioning state of the address
+  state: String?
+
+  /// Subnet is the subnet the address belongs to
+  subnet: String?
+}
+
+/// ENI is the AWS ENI specific status of the node.
+class StatusEni {
+  /// ENIs is the list of ENIs on the node
+  enis: Mapping<String, EniEnis>?
+}
+
+/// ENI represents an AWS Elastic Network Interface
+///
+/// More details: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
+class EniEnis {
+  /// Addresses is the list of all secondary IPs associated with the ENI
+  addresses: Listing<String>?
+
+  /// AvailabilityZone is the availability zone of the ENI
+  `availability-zone`: String?
+
+  /// Description is the description field of the ENI
+  description: String?
+
+  /// ID is the ENI ID
+  id: String?
+
+  /// IP is the primary IP of the ENI
+  ip: String?
+
+  /// MAC is the mac address of the ENI
+  mac: String?
+
+  /// Number is the interface index, it used in combination with FirstInterfaceIndex
+  number: Int?
+
+  /// Prefixes is the list of all /28 prefixes associated with the ENI
+  prefixes: Listing<String>?
+
+  /// PublicIP is the public IP associated with the ENI
+  `public-ip`: String?
+
+  /// SecurityGroups are the security groups associated with the ENI
+  `security-groups`: Listing<String>?
+
+  /// Subnet is the subnet the ENI is associated with
+  subnet: Subnet?
+
+  /// Tags is the set of tags of the ENI. Used to detect ENIs which should not be managed by Cilium
+  tags: Mapping<String, String>?
+
+  /// VPC is the VPC information to which the ENI is attached to
+  vpc: EnisVpc?
+}
+
+/// Subnet is the subnet the ENI is associated with
+class Subnet {
+  /// CIDR is the CIDR range associated with the subnet
+  cidr: String?
+
+  /// ID is the ID of the subnet
+  id: String?
+}
+
+/// VPC is the VPC information to which the ENI is attached to
+class EnisVpc {
+  /// CIDRs is the list of CIDR ranges associated with the VPC
+  cidrs: Listing<String>?
+
+  /// / ID is the ID of a VPC
+  id: String?
+
+  /// PrimaryCIDR is the primary CIDR of the VPC
+  `primary-cidr`: String?
+}
+
+/// IPAM is the IPAM status of the node.
+class StatusIpam {
+  /// AssignedStaticIP is the static IP assigned to the node (ex: public Elastic IP address in AWS)
+  `assigned-static-ip`: String?
+
+  /// IPv6Used lists all IPv6 addresses out of Spec.IPAM.IPv6Pool which have been allocated and are in
+  /// use.
+  `ipv6-used`: Mapping<String, Used>?
+
+  /// Operator is the Operator status of the node
+  `operator-status`: OperatorStatus?
+
+  /// PodCIDRs lists the status of each pod CIDR allocated to this node.
+  `pod-cidrs`: Mapping<String, PodCidrs>?
+
+  /// ReleaseIPs tracks the state for every IPv4 address considered for release. The value can be one of
+  /// the following strings: * marked-for-release : Set by operator as possible candidate for IP *
+  /// ready-for-release : Acknowledged as safe to release by agent * do-not-release : IP already in use /
+  /// not owned by the node. Set by agent * released : IP successfully released. Set by operator
+  `release-ips`: Mapping<String, "marked-for-release"|"ready-for-release"|"do-not-release"|"released">?
+
+  /// ReleaseIPv6s tracks the state for every IPv6 address considered for release. The value can be one
+  /// of the following strings: * marked-for-release : Set by operator as possible candidate for IP *
+  /// ready-for-release : Acknowledged as safe to release by agent * do-not-release : IP already in use /
+  /// not owned by the node. Set by agent * released : IP successfully released. Set by operator
+  `release-ipv6s`: Mapping<String, "marked-for-release"|"ready-for-release"|"do-not-release"|"released">?
+
+  /// Used lists all IPv4 addresses out of Spec.IPAM.Pool which have been allocated and are in use.
+  used: Mapping<String, Used>?
+}
+
+/// Operator is the Operator status of the node
+class OperatorStatus {
+  /// Error is the error message set by cilium-operator.
+  error: String?
+}
+
+class PodCidrs {
+  /// Status describes the status of a pod CIDR
+  status: ("released"|"depleted"|"in-use")?
+}

--- a/packages/io.cilium/v2/CiliumNodeConfig.pkl
+++ b/packages/io.cilium/v2/CiliumNodeConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumNodeConfig is a list of configuration key-value pairs. It is applied to nodes indicated by a
 /// label selector.
 ///

--- a/packages/io.cilium/v2/CiliumNodeConfig.pkl
+++ b/packages/io.cilium/v2/CiliumNodeConfig.pkl
@@ -1,0 +1,65 @@
+/// CiliumNodeConfig is a list of configuration key-value pairs. It is applied to nodes indicated by a
+/// label selector.
+///
+/// If multiple overrides apply to the same node, they will be ordered by name with later Overrides
+/// overwriting any conflicting keys.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodeconfigs.yaml>.
+module io.cilium.v2.CiliumNodeConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2"
+
+fixed kind: "CiliumNodeConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the desired Cilium configuration overrides for a given node
+spec: Spec
+
+/// Spec is the desired Cilium configuration overrides for a given node
+class Spec {
+  /// Defaults is treated the same as the cilium-config ConfigMap - a set of key-value pairs parsed by
+  /// the agent and operator processes. Each key must be a valid config-map data field (i.e. a-z, A-Z, -,
+  /// _, and .)
+  defaults: Mapping<String, String>
+
+  /// NodeSelector is a label selector that determines to which nodes this configuration applies. If not
+  /// supplied, then this config applies to no nodes. If empty, then it applies to all nodes.
+  nodeSelector: NodeSelector
+}
+
+/// NodeSelector is a label selector that determines to which nodes this configuration applies. If not
+/// supplied, then this config applies to no nodes. If empty, then it applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: String
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPAdvertisement.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPAdvertisement.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPAdvertisement is the Schema for the ciliumbgpadvertisements API
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2alpha1/CiliumBGPAdvertisement.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPAdvertisement.pkl
@@ -1,0 +1,126 @@
+/// CiliumBGPAdvertisement is the Schema for the ciliumbgpadvertisements API
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml>.
+module io.cilium.v2alpha1.CiliumBGPAdvertisement
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumBGPAdvertisement"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec
+
+class Spec {
+  /// Advertisements is a list of BGP advertisements.
+  advertisements: Listing<Advertisement>
+}
+
+/// BGPAdvertisement defines which routes Cilium should advertise to BGP peers. Optionally, additional
+/// attributes can be set to the advertised routes.
+class Advertisement {
+  /// AdvertisementType defines type of advertisement which has to be advertised.
+  advertisementType: "PodCIDR"|"CiliumPodIPPool"|"Service"
+
+  /// Attributes defines additional attributes to set to the advertised routes. If not specified, no
+  /// additional attributes are set.
+  attributes: Attributes?
+
+  /// Selector is a label selector to select objects of the type specified by AdvertisementType. For the
+  /// PodCIDR AdvertisementType it is not applicable. For other advertisement types, if not specified, no
+  /// objects of the type specified by AdvertisementType are selected for advertisement.
+  selector: Selector?
+
+  /// Service defines configuration options for advertisementType service.
+  service: Service?
+}
+
+/// Attributes defines additional attributes to set to the advertised routes. If not specified, no
+/// additional attributes are set.
+class Attributes {
+  /// Communities sets the community attributes in the route. If not specified, no community attribute is
+  /// set.
+  communities: Communities?
+
+  /// LocalPreference sets the local preference attribute in the route. If not specified, no local
+  /// preference attribute is set.
+  localPreference: Int?
+}
+
+/// Communities sets the community attributes in the route. If not specified, no community attribute is
+/// set.
+class Communities {
+  /// Large holds a list of the BGP Large Communities Attribute (RFC 8092) values.
+  large: Listing<String(matches(Regex("^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$")))>?
+
+  /// Standard holds a list of "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as
+  /// numeric values.
+  standard: Listing<String(matches(Regex("^([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])$|^([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$")))>?
+
+  /// WellKnown holds a list "standard" 32-bit BGP Communities Attribute (RFC 1997) values defined as
+  /// well-known string aliases to their numeric values.
+  wellKnown: Listing<
+    "internet"
+    |"planned-shut"
+    |"accept-own"
+    |"route-filter-translated-v4"
+    |"route-filter-v4"
+    |"route-filter-translated-v6"
+    |"route-filter-v6"
+    |"llgr-stale"
+    |"no-llgr"
+    |"blackhole"
+    |"no-export"
+    |"no-advertise"
+    |"no-export-subconfed"
+    |"no-peer">?
+}
+
+/// Selector is a label selector to select objects of the type specified by AdvertisementType. For the
+/// PodCIDR AdvertisementType it is not applicable. For other advertisement types, if not specified, no
+/// objects of the type specified by AdvertisementType are selected for advertisement.
+class Selector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Service defines configuration options for advertisementType service.
+class Service {
+  /// Addresses is a list of service address types which needs to be advertised via BGP.
+  addresses: Listing<"LoadBalancerIP"|"ClusterIP"|"ExternalIP">(!isEmpty)
+
+  /// IPv4 mask to aggregate BGP route advertisements of service
+  aggregationLengthIPv4: Int(isBetween(0, 31))?
+
+  /// IPv6 mask to aggregate BGP route advertisements of service
+  aggregationLengthIPv6: Int(isBetween(0, 127))?
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPClusterConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPClusterConfig.pkl
@@ -1,0 +1,155 @@
+/// CiliumBGPClusterConfig is the Schema for the CiliumBGPClusterConfig API
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml>.
+module io.cilium.v2alpha1.CiliumBGPClusterConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumBGPClusterConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec defines the desired cluster configuration of the BGP control plane.
+spec: Spec
+
+/// Status is a running status of the cluster configuration
+status: Status?
+
+/// Spec defines the desired cluster configuration of the BGP control plane.
+class Spec {
+  /// A list of CiliumBGPInstance(s) which instructs the BGP control plane how to instantiate virtual BGP
+  /// routers.
+  bgpInstances: Listing<BgpInstance>(length.isBetween(1, 16))
+
+  /// NodeSelector selects a group of nodes where this BGP Cluster config applies. If empty / nil this
+  /// config applies to all nodes.
+  nodeSelector: NodeSelector?
+}
+
+class BgpInstance {
+  /// LocalASN is the ASN of this BGP instance. Supports extended 32bit ASNs.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is the port on which the BGP daemon listens for incoming connections.
+  ///
+  /// If not specified, BGP instance will not listen for incoming connections.
+  localPort: Int(isBetween(1, 65535))?
+
+  /// Name is the name of the BGP instance. It is a unique identifier for the BGP instance within the
+  /// cluster configuration.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of neighboring BGP peers for this virtual router
+  peers: Listing<Peer>?
+}
+
+class Peer {
+  /// Name is the name of the BGP peer. It is a unique identifier for the peer within the BGP instance.
+  name: String(length.isBetween(1, 255))
+
+  /// PeerASN is the ASN of the peer BGP router. Supports extended 32bit ASNs.
+  ///
+  /// If peerASN is 0, the BGP OPEN message validation of ASN will be disabled and ASN will be determined
+  /// based on peer's OPEN message.
+  ///
+  /// Default if undefined: `0`
+  peerASN: UInt32?
+
+  /// PeerAddress is the IP address of the neighbor. Supports IPv4 and IPv6 addresses.
+  peerAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+  /// configuration is used for this peer.
+  peerConfigRef: PeerConfigRef?
+}
+
+/// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+/// configuration is used for this peer.
+class PeerConfigRef {
+  /// Group is the group of the peer config resource. If not specified, the default of "cilium.io" is
+  /// used.
+  ///
+  /// Default if undefined: `"cilium.io"`
+  group: String?
+
+  /// Kind is the kind of the peer config resource. If not specified, the default of
+  /// "CiliumBGPPeerConfig" is used.
+  ///
+  /// Default if undefined: `"CiliumBGPPeerConfig"`
+  kind: String?
+
+  /// Name is the name of the peer config resource. Name refers to the name of a Kubernetes object
+  /// (typically a CiliumBGPPeerConfig).
+  name: String
+}
+
+/// NodeSelector selects a group of nodes where this BGP Cluster config applies. If empty / nil this
+/// config applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Status is a running status of the cluster configuration
+class Status {
+  /// The current conditions of the CiliumBGPClusterConfig
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPClusterConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPClusterConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPClusterConfig is the Schema for the CiliumBGPClusterConfig API
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2alpha1/CiliumBGPNodeConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPNodeConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPNodeConfig is node local configuration for BGP agent. Name of the object should be node
 /// name. This resource will be created by Cilium operator and is read-only for the users.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumBGPNodeConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPNodeConfig.pkl
@@ -1,0 +1,206 @@
+/// CiliumBGPNodeConfig is node local configuration for BGP agent. Name of the object should be node
+/// name. This resource will be created by Cilium operator and is read-only for the users.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml>.
+module io.cilium.v2alpha1.CiliumBGPNodeConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumBGPNodeConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+spec: Spec
+
+/// Status is the most recently observed status of the CiliumBGPNodeConfig.
+status: Status?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+class Spec {
+  /// BGPInstances is a list of BGP router instances on the node.
+  bgpInstances: Listing<BgpInstance>(length.isBetween(1, 16))
+}
+
+/// CiliumBGPNodeInstance is a single BGP router instance configuration on the node.
+class BgpInstance {
+  /// LocalASN is the ASN of this virtual router. Supports extended 32bit ASNs.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is the port on which the BGP daemon listens for incoming connections.
+  ///
+  /// If not specified, BGP instance will not listen for incoming connections.
+  localPort: Int(isBetween(1, 65535))?
+
+  /// Name is the name of the BGP instance. This name is used to identify the BGP instance on the node.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of neighboring BGP peers for this virtual router
+  peers: Listing<Peer>?
+
+  /// RouterID is the BGP router ID of this virtual router. This configuration is derived from
+  /// CiliumBGPNodeConfigOverride resource.
+  ///
+  /// If not specified, the router ID will be derived from the node local address.
+  routerID: String?
+}
+
+class Peer {
+  /// LocalAddress is the IP address of the local interface to use for the peering session. This
+  /// configuration is derived from CiliumBGPNodeConfigOverride resource. If not specified, the local
+  /// address will be used for setting up peering.
+  localAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// Name is the name of the BGP peer. This name is used to identify the BGP peer for the BGP instance.
+  name: String
+
+  /// PeerASN is the ASN of the peer BGP router. Supports extended 32bit ASNs
+  peerASN: UInt32?
+
+  /// PeerAddress is the IP address of the neighbor. Supports IPv4 and IPv6 addresses.
+  peerAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+  /// configuration is used for this peer.
+  peerConfigRef: PeerConfigRef?
+}
+
+/// PeerConfigRef is a reference to a peer configuration resource. If not specified, the default BGP
+/// configuration is used for this peer.
+class PeerConfigRef {
+  /// Group is the group of the peer config resource. If not specified, the default of "cilium.io" is
+  /// used.
+  ///
+  /// Default if undefined: `"cilium.io"`
+  group: String?
+
+  /// Kind is the kind of the peer config resource. If not specified, the default of
+  /// "CiliumBGPPeerConfig" is used.
+  ///
+  /// Default if undefined: `"CiliumBGPPeerConfig"`
+  kind: String?
+
+  /// Name is the name of the peer config resource. Name refers to the name of a Kubernetes object
+  /// (typically a CiliumBGPPeerConfig).
+  name: String
+}
+
+/// Status is the most recently observed status of the CiliumBGPNodeConfig.
+class Status {
+  /// BGPInstances is the status of the BGP instances on the node.
+  bgpInstances: Listing<StatusBgpInstance>?
+
+  /// The current conditions of the CiliumBGPNodeConfig
+  conditions: Listing<Condition>?
+}
+
+class StatusBgpInstance {
+  /// LocalASN is the ASN of this BGP instance.
+  localASN: Int?
+
+  /// Name is the name of the BGP instance. This name is used to identify the BGP instance on the node.
+  name: String
+
+  /// PeerStatuses is the state of the BGP peers for this BGP instance.
+  peers: Listing<BgpInstancePeer>?
+}
+
+/// CiliumBGPNodePeerStatus is the status of a BGP peer.
+class BgpInstancePeer {
+  /// EstablishedTime is the time when the peering session was established. It is represented in RFC3339
+  /// form and is in UTC.
+  establishedTime: String?
+
+  /// Name is the name of the BGP peer.
+  name: String
+
+  /// PeerASN is the ASN of the neighbor.
+  peerASN: Int?
+
+  /// PeerAddress is the IP address of the neighbor.
+  peerAddress: String
+
+  /// PeeringState is last known state of the peering session.
+  peeringState: String?
+
+  /// RouteCount is the number of routes exchanged with this peer per AFI/SAFI.
+  routeCount: Listing<RouteCount>?
+
+  /// Timers is the state of the negotiated BGP timers for this peer.
+  timers: Timers?
+}
+
+class RouteCount {
+  /// Advertised is the number of routes advertised to this peer.
+  advertised: Int?
+
+  /// Afi is the Address Family Identifier (AFI) of the family.
+  afi: "ipv4"|"ipv6"|"l2vpn"|"ls"|"opaque"
+
+  /// Received is the number of routes received from this peer.
+  received: Int?
+
+  /// Safi is the Subsequent Address Family Identifier (SAFI) of the family.
+  safi: 
+    "unicast"
+    |"multicast"
+    |"mpls_label"
+    |"encapsulation"
+    |"vpls"
+    |"evpn"
+    |"ls"
+    |"sr_policy"
+    |"mup"
+    |"mpls_vpn"
+    |"mpls_vpn_multicast"
+    |"route_target_constraints"
+    |"flowspec_unicast"
+    |"flowspec_vpn"
+    |"key_value"
+}
+
+/// Timers is the state of the negotiated BGP timers for this peer.
+class Timers {
+  /// AppliedHoldTimeSeconds is the negotiated hold time for this peer.
+  appliedHoldTimeSeconds: Int?
+
+  /// AppliedKeepaliveSeconds is the negotiated keepalive time for this peer.
+  appliedKeepaliveSeconds: Int?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPNodeConfigOverride.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPNodeConfigOverride.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig. It allows
 /// fine-tuning of BGP behavior on a per-node basis. For the override to be effective, the names in
 /// CiliumBGPNodeConfigOverride and CiliumBGPNodeConfig must match exactly. This matching ensures that

--- a/packages/io.cilium/v2alpha1/CiliumBGPNodeConfigOverride.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPNodeConfigOverride.pkl
@@ -1,0 +1,62 @@
+/// CiliumBGPNodeConfigOverride specifies configuration overrides for a CiliumBGPNodeConfig. It allows
+/// fine-tuning of BGP behavior on a per-node basis. For the override to be effective, the names in
+/// CiliumBGPNodeConfigOverride and CiliumBGPNodeConfig must match exactly. This matching ensures that
+/// specific node configurations are applied correctly and only where intended.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigoverrides.yaml>.
+module io.cilium.v2alpha1.CiliumBGPNodeConfigOverride
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumBGPNodeConfigOverride"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+spec: Spec
+
+/// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+class Spec {
+  /// BGPInstances is a list of BGP instances to override.
+  bgpInstances: Listing<BgpInstance>(!isEmpty)
+}
+
+/// CiliumBGPNodeConfigInstanceOverride defines configuration options which can be overridden for a
+/// specific BGP instance.
+class BgpInstance {
+  /// LocalASN is the ASN to use for this BGP instance.
+  localASN: Int(isBetween(1, 4294967295))?
+
+  /// LocalPort is port to use for this BGP instance.
+  localPort: Int?
+
+  /// Name is the name of the BGP instance for which the configuration is overridden.
+  name: String(length.isBetween(1, 255))
+
+  /// Peers is a list of peer configurations to override.
+  peers: Listing<Peer>?
+
+  /// RouterID is BGP router id to use for this instance. It must be unique across all BGP instances.
+  routerID: String?
+}
+
+/// CiliumBGPNodeConfigPeerOverride defines configuration options which can be overridden for a specific
+/// peer.
+class Peer {
+  /// LocalAddress is the IP address to use for connecting to this peer.
+  localAddress: String(matches(Regex(#"((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))"#)))?
+
+  /// LocalPort is source port to use for connecting to this peer.
+  localPort: Int?
+
+  /// Name is the name of the peer for which the configuration is overridden.
+  name: String(length.isBetween(1, 255))
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPPeerConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPPeerConfig.pkl
@@ -1,0 +1,217 @@
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml>.
+module io.cilium.v2alpha1.CiliumBGPPeerConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumBGPPeerConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+spec: Spec
+
+/// Status is the running status of the CiliumBGPPeerConfig
+status: Status?
+
+/// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+class Spec {
+  /// AuthSecretRef is the name of the secret to use to fetch a TCP authentication password for this
+  /// peer.
+  ///
+  /// If not specified, no authentication is used.
+  authSecretRef: String?
+
+  /// EBGPMultihopTTL controls the multi-hop feature for eBGP peers. Its value defines the Time To Live
+  /// (TTL) value used in BGP packets sent to the peer.
+  ///
+  /// If not specified, EBGP multihop is disabled. This field is ignored for iBGP neighbors.
+  ///
+  /// Default if undefined: `1`
+  ebgpMultihop: Int(isBetween(1, 255))?
+
+  /// Families, if provided, defines a set of AFI/SAFIs the speaker will negotiate with it's peer.
+  ///
+  /// If not specified, the default families of IPv6/unicast and IPv4/unicast will be created.
+  families: Listing<Family>?
+
+  /// GracefulRestart defines graceful restart parameters which are negotiated with this peer.
+  ///
+  /// If not specified, the graceful restart capability is disabled.
+  gracefulRestart: GracefulRestart?
+
+  /// Timers defines the BGP timers for the peer.
+  ///
+  /// If not specified, the default timers are used.
+  timers: Timers?
+
+  /// Transport defines the BGP transport parameters for the peer.
+  ///
+  /// If not specified, the default transport parameters are used.
+  transport: Transport?
+}
+
+/// CiliumBGPFamilyWithAdverts represents a AFI/SAFI address family pair along with reference to BGP
+/// Advertisements.
+class Family {
+  /// Advertisements selects group of BGP Advertisement(s) to advertise for this family.
+  ///
+  /// If not specified, no advertisements are sent for this family.
+  advertisements: Advertisements?
+
+  /// Afi is the Address Family Identifier (AFI) of the family.
+  afi: "ipv4"|"ipv6"|"l2vpn"|"ls"|"opaque"
+
+  /// Safi is the Subsequent Address Family Identifier (SAFI) of the family.
+  safi: 
+    "unicast"
+    |"multicast"
+    |"mpls_label"
+    |"encapsulation"
+    |"vpls"
+    |"evpn"
+    |"ls"
+    |"sr_policy"
+    |"mup"
+    |"mpls_vpn"
+    |"mpls_vpn_multicast"
+    |"route_target_constraints"
+    |"flowspec_unicast"
+    |"flowspec_vpn"
+    |"key_value"
+}
+
+/// Advertisements selects group of BGP Advertisement(s) to advertise for this family.
+///
+/// If not specified, no advertisements are sent for this family.
+class Advertisements {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// GracefulRestart defines graceful restart parameters which are negotiated with this peer.
+///
+/// If not specified, the graceful restart capability is disabled.
+class GracefulRestart {
+  /// Enabled flag, when set enables graceful restart capability.
+  enabled: Boolean
+
+  /// RestartTimeSeconds is the estimated time it will take for the BGP session to be re-established with
+  /// peer after a restart. After this period, peer will remove stale routes. This is described RFC 4724
+  /// section 4.2.
+  ///
+  /// Default if undefined: `120`
+  restartTimeSeconds: Int(isBetween(1, 4095))?
+}
+
+/// Timers defines the BGP timers for the peer.
+///
+/// If not specified, the default timers are used.
+class Timers {
+  /// ConnectRetryTimeSeconds defines the initial value for the BGP ConnectRetryTimer (RFC 4271, Section
+  /// 8).
+  ///
+  /// If not specified, defaults to 120 seconds.
+  ///
+  /// Default if undefined: `120`
+  connectRetryTimeSeconds: Int(isBetween(1, 2147483647))?
+
+  /// HoldTimeSeconds defines the initial value for the BGP HoldTimer (RFC 4271, Section 4.2). Updating
+  /// this value will cause a session reset.
+  ///
+  /// If not specified, defaults to 90 seconds.
+  ///
+  /// Default if undefined: `90`
+  holdTimeSeconds: Int(isBetween(3, 65535))?
+
+  /// KeepaliveTimeSeconds defines the initial value for the BGP KeepaliveTimer (RFC 4271, Section 8). It
+  /// can not be larger than HoldTimeSeconds. Updating this value will cause a session reset.
+  ///
+  /// If not specified, defaults to 30 seconds.
+  ///
+  /// Default if undefined: `30`
+  keepAliveTimeSeconds: Int(isBetween(1, 65535))?
+}
+
+/// Transport defines the BGP transport parameters for the peer.
+///
+/// If not specified, the default transport parameters are used.
+class Transport {
+  /// Deprecated LocalPort is the local port to be used for the BGP session.
+  ///
+  /// If not specified, ephemeral port will be picked to initiate a connection.
+  ///
+  /// This field is deprecated and will be removed in a future release. Local port configuration is
+  /// unnecessary and is not recommended.
+  localPort: Int(isBetween(1, 65535))?
+
+  /// PeerPort is the peer port to be used for the BGP session.
+  ///
+  /// If not specified, defaults to TCP port 179.
+  ///
+  /// Default if undefined: `179`
+  peerPort: Int(isBetween(1, 65535))?
+}
+
+/// Status is the running status of the CiliumBGPPeerConfig
+class Status {
+  /// The current conditions of the CiliumBGPPeerConfig
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumBGPPeerConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumBGPPeerConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// This module was generated from the CustomResourceDefinition at
 /// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgppeerconfigs.yaml>.
 module io.cilium.v2alpha1.CiliumBGPPeerConfig

--- a/packages/io.cilium/v2alpha1/CiliumCIDRGroup.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumCIDRGroup.pkl
@@ -1,0 +1,26 @@
+/// CiliumCIDRGroup is a list of external CIDRs (i.e: CIDRs selecting peers outside the clusters) that
+/// can be referenced as a single entity from CiliumNetworkPolicies.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumcidrgroups.yaml>.
+module io.cilium.v2alpha1.CiliumCIDRGroup
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumCIDRGroup"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec
+
+class Spec {
+  /// ExternalCIDRs is a list of CIDRs selecting peers outside the clusters.
+  externalCIDRs: Listing<String>(length >= 0)
+}

--- a/packages/io.cilium/v2alpha1/CiliumCIDRGroup.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumCIDRGroup.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumCIDRGroup is a list of external CIDRs (i.e: CIDRs selecting peers outside the clusters) that
 /// can be referenced as a single entity from CiliumNetworkPolicies.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumEndpointSlice.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumEndpointSlice.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumEndpointSlice contains a group of CoreCiliumendpoints.
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/packages/io.cilium/v2alpha1/CiliumEndpointSlice.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumEndpointSlice.pkl
@@ -1,0 +1,88 @@
+/// CiliumEndpointSlice contains a group of CoreCiliumendpoints.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml>.
+module io.cilium.v2alpha1.CiliumEndpointSlice
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumEndpointSlice"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Endpoints is a list of coreCEPs packed in a CiliumEndpointSlice
+endpoints: Listing<Endpoint>
+
+/// Namespace indicate as CiliumEndpointSlice namespace. All the CiliumEndpoints within the same
+/// namespace are put together in CiliumEndpointSlice.
+namespace: String?
+
+/// CoreCiliumEndpoint is slim version of status of CiliumEndpoint.
+class Endpoint {
+  /// EncryptionSpec defines the encryption relevant configuration of a node.
+  encryption: Encryption?
+
+  /// IdentityID is the numeric identity of the endpoint
+  id: Int?
+
+  /// Name indicate as CiliumEndpoint name.
+  name: String?
+
+  /// NamedPorts List of named Layer 4 port and protocol pairs which will be used in Network Policy
+  /// specs.
+  ///
+  /// swagger:model NamedPorts
+  `named-ports`: Listing<NamedPort>?
+
+  /// EndpointNetworking is the addressing information of an endpoint.
+  networking: Networking?
+
+  /// PodUID is the UID of the Pod that owns this endpoint.
+  `pod-uid`: String?
+
+  /// ServiceAccount is the service account of the endpoint.
+  `service-account`: String?
+}
+
+/// EncryptionSpec defines the encryption relevant configuration of a node.
+class Encryption {
+  /// Key is the index to the key to use for encryption or 0 if encryption is disabled.
+  key: Int?
+}
+
+/// Port Layer 4 port / protocol pair
+///
+/// swagger:model Port
+class NamedPort {
+  /// Optional layer 4 port name
+  name: String?
+
+  /// Layer 4 port number
+  port: Int?
+
+  /// Layer 4 protocol Enum: ["TCP","UDP","SCTP","ICMP","ICMPV6","ANY"]
+  protocol: String?
+}
+
+/// EndpointNetworking is the addressing information of an endpoint.
+class Networking {
+  /// IP4/6 addresses assigned to this Endpoint
+  addressing: Listing<Addressing>
+
+  /// NodeIP is the IP of the node the endpoint is running on. The IP must be reachable between nodes.
+  node: String?
+}
+
+/// AddressPair is a pair of IPv4 and/or IPv6 address.
+class Addressing {
+  ipv4: String?
+
+  ipv6: String?
+}

--- a/packages/io.cilium/v2alpha1/CiliumGatewayClassConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumGatewayClassConfig.pkl
@@ -1,0 +1,110 @@
+/// CiliumGatewayClassConfig is a Kubernetes third-party resource which is used to configure Gateways
+/// owned by GatewayClass.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml>.
+module io.cilium.v2alpha1.CiliumGatewayClassConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumGatewayClassConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is a human-readable of a GatewayClass configuration.
+spec: Spec?
+
+/// Status is the status of the policy.
+status: Status?
+
+/// Spec is a human-readable of a GatewayClass configuration.
+class Spec {
+  /// Description helps describe a GatewayClass configuration with more details.
+  description: String(length <= 64)?
+
+  /// Service specifies the configuration for the generated Service. Note that not all fields from
+  /// upstream Service.Spec are supported
+  service: Service?
+}
+
+/// Service specifies the configuration for the generated Service. Note that not all fields from upstream
+/// Service.Spec are supported
+class Service {
+  /// Sets the Service.Spec.AllocateLoadBalancerNodePorts in generated Service objects to the given
+  /// value.
+  allocateLoadBalancerNodePorts: Boolean?
+
+  /// Sets the Service.Spec.ExternalTrafficPolicy in generated Service objects to the given value.
+  ///
+  /// Default if undefined: `"Cluster"`
+  externalTrafficPolicy: String?
+
+  /// Sets the Service.Spec.IPFamilies in generated Service objects to the given value.
+  ipFamilies: Listing<String>?
+
+  /// Sets the Service.Spec.IPFamilyPolicy in generated Service objects to the given value.
+  ipFamilyPolicy: String?
+
+  /// Sets the Service.Spec.LoadBalancerClass in generated Service objects to the given value.
+  loadBalancerClass: String?
+
+  /// Sets the Service.Spec.LoadBalancerSourceRanges in generated Service objects to the given value.
+  loadBalancerSourceRanges: Listing<String>?
+
+  /// LoadBalancerSourceRangesPolicy defines the policy for the LoadBalancerSourceRanges if the incoming
+  /// traffic is allowed or denied.
+  ///
+  /// Default if undefined: `"Allow"`
+  loadBalancerSourceRangesPolicy: ("Allow"|"Deny")?
+
+  /// Sets the Service.Spec.TrafficDistribution in generated Service objects to the given value.
+  trafficDistribution: String?
+
+  /// Sets the Service.Spec.Type in generated Service objects to the given value. Only LoadBalancer and
+  /// NodePort are supported.
+  ///
+  /// Default if undefined: `"LoadBalancer"`
+  type: ("LoadBalancer"|"NodePort")?
+}
+
+/// Status is the status of the policy.
+class Status {
+  /// Current service state
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumGatewayClassConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumGatewayClassConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumGatewayClassConfig is a Kubernetes third-party resource which is used to configure Gateways
 /// owned by GatewayClass.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumL2AnnouncementPolicy.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumL2AnnouncementPolicy.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumL2AnnouncementPolicy is a Kubernetes third-party resource which is used to defined which nodes
 /// should announce what services on the L2 network.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumL2AnnouncementPolicy.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumL2AnnouncementPolicy.pkl
@@ -1,0 +1,139 @@
+/// CiliumL2AnnouncementPolicy is a Kubernetes third-party resource which is used to defined which nodes
+/// should announce what services on the L2 network.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliuml2announcementpolicies.yaml>.
+module io.cilium.v2alpha1.CiliumL2AnnouncementPolicy
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumL2AnnouncementPolicy"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is a human readable description of a L2 announcement policy
+spec: Spec?
+
+/// Status is the status of the policy.
+status: Status?
+
+/// Spec is a human readable description of a L2 announcement policy
+class Spec {
+  /// If true, the external IPs of the services are announced
+  externalIPs: Boolean?
+
+  /// A list of regular expressions that express which network interface(s) should be used to announce
+  /// the services over. If nil, all network interfaces are used.
+  interfaces: Listing<String>?
+
+  /// If true, the loadbalancer IPs of the services are announced
+  ///
+  /// If nil this policy applies to all services.
+  loadBalancerIPs: Boolean?
+
+  /// NodeSelector selects a group of nodes which will announce the IPs for the services selected by the
+  /// service selector.
+  ///
+  /// If nil this policy applies to all nodes.
+  nodeSelector: NodeSelector?
+
+  /// ServiceSelector selects a set of services which will be announced over L2 networks. The
+  /// loadBalancerClass for a service must be nil or specify a supported class, e.g.
+  /// "io.cilium/l2-announcer". Refer to the following document for additional details regarding load
+  /// balancer classes:
+  ///
+  /// https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+  ///
+  /// If nil this policy applies to all services.
+  serviceSelector: ServiceSelector?
+}
+
+/// NodeSelector selects a group of nodes which will announce the IPs for the services selected by the
+/// service selector.
+///
+/// If nil this policy applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<ServiceSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class ServiceSelectorMatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// ServiceSelector selects a set of services which will be announced over L2 networks. The
+/// loadBalancerClass for a service must be nil or specify a supported class, e.g.
+/// "io.cilium/l2-announcer". Refer to the following document for additional details regarding load
+/// balancer classes:
+///
+/// https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+///
+/// If nil this policy applies to all services.
+class ServiceSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<ServiceSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// Status is the status of the policy.
+class Status {
+  /// Current service state
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumLoadBalancerIPPool.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumLoadBalancerIPPool.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumLoadBalancerIPPool is a Kubernetes third-party resource which is used to defined pools of IPs
 /// which the operator can use to allocate and advertise IPs for Services of type LoadBalancer.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumLoadBalancerIPPool.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumLoadBalancerIPPool.pkl
@@ -1,0 +1,124 @@
+/// CiliumLoadBalancerIPPool is a Kubernetes third-party resource which is used to defined pools of IPs
+/// which the operator can use to allocate and advertise IPs for Services of type LoadBalancer.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumloadbalancerippools.yaml>.
+module io.cilium.v2alpha1.CiliumLoadBalancerIPPool
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumLoadBalancerIPPool"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is a human readable description for a BGP load balancer ip pool.
+spec: Spec
+
+/// Status is the status of the IP Pool.
+///
+/// It might be possible for users to define overlapping IP Pools, we can't validate or enforce
+/// non-overlapping pools during object creation. The Cilium operator will do this validation and update
+/// the status to reflect the ability to allocate IPs from this pool.
+status: Status?
+
+/// Spec is a human readable description for a BGP load balancer ip pool.
+class Spec {
+  /// AllowFirstLastIPs, if set to `Yes` or undefined means that the first and last IPs of each CIDR will
+  /// be allocatable. If `No`, these IPs will be reserved. This field is ignored for /{31,32} and
+  /// /{127,128} CIDRs since reserving the first and last IPs would make the CIDRs unusable.
+  allowFirstLastIPs: ("Yes"|"No")?
+
+  /// Blocks is a list of CIDRs comprising this IP Pool
+  blocks: Listing<Block>?
+
+  /// Disabled, if set to true means that no new IPs will be allocated from this pool. Existing
+  /// allocations will not be removed from services.
+  ///
+  /// Default if undefined: `false`
+  disabled: Boolean?
+
+  /// ServiceSelector selects a set of services which are eligible to receive IPs from this
+  serviceSelector: ServiceSelector?
+}
+
+/// CiliumLoadBalancerIPPoolIPBlock describes a single IP block.
+class Block {
+  cidr: String?
+
+  start: String?
+
+  stop: String?
+}
+
+/// ServiceSelector selects a set of services which are eligible to receive IPs from this
+class ServiceSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// Status is the status of the IP Pool.
+///
+/// It might be possible for users to define overlapping IP Pools, we can't validate or enforce
+/// non-overlapping pools during object creation. The Cilium operator will do this validation and update
+/// the status to reflect the ability to allocate IPs from this pool.
+class Status {
+  /// Current service state
+  conditions: Listing<Condition>?
+}
+
+/// Condition contains details for one aspect of the current state of this API Resource.
+class Condition {
+  /// lastTransitionTime is the last time the condition transitioned from one status to another. This
+  /// should be when the underlying condition changed. If that is not known, then using the time when the
+  /// API field changed is acceptable.
+  lastTransitionTime: String
+
+  /// message is a human readable message indicating details about the transition. This may be an empty
+  /// string.
+  message: String(length <= 32768)
+
+  /// observedGeneration represents the .metadata.generation that the condition was set based upon. For
+  /// instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+  /// is 9, the condition is out of date with respect to the current state of the instance.
+  observedGeneration: Int(isPositive)?
+
+  /// reason contains a programmatic identifier indicating the reason for the condition's last
+  /// transition. Producers of specific condition types may define expected values and meanings for this
+  /// field, and whether the values are considered a guaranteed API. The value should be a CamelCase
+  /// string. This field may not be empty.
+  reason: String(length.isBetween(1, 1024), matches(Regex("^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$")))
+
+  /// status of the condition, one of True, False, Unknown.
+  status: "True"|"False"|"Unknown"
+
+  /// type of condition in CamelCase or in foo.example.com/CamelCase.
+  type: String(length <= 316, matches(Regex(#"^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"#)))
+}

--- a/packages/io.cilium/v2alpha1/CiliumNodeConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumNodeConfig.pkl
@@ -1,0 +1,65 @@
+/// CiliumNodeConfig is a list of configuration key-value pairs. It is applied to nodes indicated by a
+/// label selector.
+///
+/// If multiple overrides apply to the same node, they will be ordered by name with later Overrides
+/// overwriting any conflicting keys.
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodeconfigs.yaml>.
+module io.cilium.v2alpha1.CiliumNodeConfig
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumNodeConfig"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+/// Spec is the desired Cilium configuration overrides for a given node
+spec: Spec
+
+/// Spec is the desired Cilium configuration overrides for a given node
+class Spec {
+  /// Defaults is treated the same as the cilium-config ConfigMap - a set of key-value pairs parsed by
+  /// the agent and operator processes. Each key must be a valid config-map data field (i.e. a-z, A-Z, -,
+  /// _, and .)
+  defaults: Mapping<String, String>
+
+  /// NodeSelector is a label selector that determines to which nodes this configuration applies. If not
+  /// supplied, then this config applies to no nodes. If empty, then it applies to all nodes.
+  nodeSelector: NodeSelector
+}
+
+/// NodeSelector is a label selector that determines to which nodes this configuration applies. If not
+/// supplied, then this config applies to no nodes. If empty, then it applies to all nodes.
+class NodeSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<MatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class MatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: String
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}

--- a/packages/io.cilium/v2alpha1/CiliumNodeConfig.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumNodeConfig.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumNodeConfig is a list of configuration key-value pairs. It is applied to nodes indicated by a
 /// label selector.
 ///

--- a/packages/io.cilium/v2alpha1/CiliumPodIPPool.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumPodIPPool.pkl
@@ -1,0 +1,118 @@
+/// CiliumPodIPPool defines an IP pool that can be used for pooled IPAM (i.e. the multi-pool IPAM mode).
+///
+/// This module was generated from the CustomResourceDefinition at
+/// <https://raw.githubusercontent.com/cilium/cilium/refs/heads/main/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml>.
+module io.cilium.v2alpha1.CiliumPodIPPool
+
+extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
+
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "cilium.io/v2alpha1"
+
+fixed kind: "CiliumPodIPPool"
+
+/// Standard object's metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>.
+metadata: ObjectMeta?
+
+spec: Spec
+
+class Spec {
+  /// IPv4 specifies the IPv4 CIDRs and mask sizes of the pool
+  ipv4: Ipv4?
+
+  /// IPv6 specifies the IPv6 CIDRs and mask sizes of the pool
+  ipv6: Ipv6?
+
+  /// NamespaceSelector selects the set of Namespaces that are eligible to use this pool. If both
+  /// PodSelector and NamespaceSelector are specified, a Pod must match both selectors to be eligible for
+  /// IP allocation from this pool.
+  ///
+  /// If NamespaceSelector is empty, the pool can be used by Pods in any namespace (subject to
+  /// PodSelector constraints).
+  namespaceSelector: NamespaceSelector?
+
+  /// PodSelector selects the set of Pods that are eligible to receive IPs from this pool when neither
+  /// the Pod nor its Namespace specify an explicit `ipam.cilium.io/*` annotation.
+  ///
+  /// The selector can match on regular Pod labels and on the following synthetic labels that Cilium adds
+  /// for convenience:
+  ///
+  /// io.kubernetes.pod.namespace – the Pod's namespace io.kubernetes.pod.name – the Pod's name
+  ///
+  /// A single Pod must not match more than one pool for the same IP family. If multiple pools match, IP
+  /// allocation fails for that Pod and a warning event is emitted in the namespace of the Pod.
+  podSelector: PodSelector?
+}
+
+/// IPv4 specifies the IPv4 CIDRs and mask sizes of the pool
+class Ipv4 {
+  /// CIDRs is a list of IPv4 CIDRs that are part of the pool.
+  cidrs: Listing<String>(!isEmpty)
+
+  /// MaskSize is the mask size of the pool.
+  maskSize: Int(isBetween(1, 32))
+}
+
+/// IPv6 specifies the IPv6 CIDRs and mask sizes of the pool
+class Ipv6 {
+  /// CIDRs is a list of IPv6 CIDRs that are part of the pool.
+  cidrs: Listing<String>(!isEmpty)
+
+  /// MaskSize is the mask size of the pool.
+  maskSize: Int(isBetween(1, 128))
+}
+
+/// NamespaceSelector selects the set of Namespaces that are eligible to use this pool. If both
+/// PodSelector and NamespaceSelector are specified, a Pod must match both selectors to be eligible for
+/// IP allocation from this pool.
+///
+/// If NamespaceSelector is empty, the pool can be used by Pods in any namespace (subject to PodSelector
+/// constraints).
+class NamespaceSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<PodSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}
+
+/// A label selector requirement is a selector that contains values, a key, and an operator that relates
+/// the key and values.
+class PodSelectorMatchExpression {
+  /// key is the label key that the selector applies to.
+  key: String
+
+  /// operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists
+  /// and DoesNotExist.
+  operator: "In"|"NotIn"|"Exists"|"DoesNotExist"
+
+  /// values is an array of string values. If the operator is In or NotIn, the values array must be
+  /// non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is
+  /// replaced during a strategic merge patch.
+  values: Listing<String>?
+}
+
+/// PodSelector selects the set of Pods that are eligible to receive IPs from this pool when neither the
+/// Pod nor its Namespace specify an explicit `ipam.cilium.io/*` annotation.
+///
+/// The selector can match on regular Pod labels and on the following synthetic labels that Cilium adds
+/// for convenience:
+///
+/// io.kubernetes.pod.namespace – the Pod's namespace io.kubernetes.pod.name – the Pod's name
+///
+/// A single Pod must not match more than one pool for the same IP family. If multiple pools match, IP
+/// allocation fails for that Pod and a warning event is emitted in the namespace of the Pod.
+class PodSelector {
+  /// matchExpressions is a list of label selector requirements. The requirements are ANDed.
+  matchExpressions: Listing<PodSelectorMatchExpression>?
+
+  /// matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is
+  /// equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and
+  /// the values array contains only "value". The requirements are ANDed.
+  matchLabels: Mapping<String, String(length <= 63, matches(Regex("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")))>?
+}

--- a/packages/io.cilium/v2alpha1/CiliumPodIPPool.pkl
+++ b/packages/io.cilium/v2alpha1/CiliumPodIPPool.pkl
@@ -1,3 +1,20 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+
 /// CiliumPodIPPool defines an IP pool that can be used for pooled IPAM (i.e. the multi-pool IPAM mode).
 ///
 /// This module was generated from the CustomResourceDefinition at

--- a/scripts/PklProject.deps.json
+++ b/scripts/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions.contrib@1.0.8",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions.contrib@1.0.9",
       "path": "../packages/com.github.actions.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -18,7 +18,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.2",
       "path": "../packages/com.github.actions"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/io.github.typesafegithub@1": {


### PR DESCRIPTION
Cilium is a widely used CNI for k8s clusters. We're trying to keep all our k8s configs in pkl, so we needed the pkl schemas. I used the k8s.contrib.crd generator to generate the CRDs. I also included some tests, similar to the k8s.networking.gateway CRDs. 