### PR TITLE
Work around incorrect YAML parsing in Dependabot

### DIFF
--- a/packages/com.github.dependabot/PklProject
+++ b/packages/com.github.dependabot/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.0.1"
+  version = "1.0.2"
 }

--- a/packages/com.github.dependabot/examples/basic.pkl
+++ b/packages/com.github.dependabot/examples/basic.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ updates {
     directory = "/"
     schedule {
       interval = "weekly"
+      time = "04:00" // https://github.com/apple/pkl/issues/1543
     }
   }
 }

--- a/packages/com.github.dependabot/tests/examples.pkl-expected.pcf
+++ b/packages/com.github.dependabot/tests/examples.pkl-expected.pcf
@@ -15,6 +15,7 @@ examples {
       directory: /
       schedule:
         interval: weekly
+        time: "04:00"
     
     """
   }

--- a/packages/com.github.dependabot/v2/Dependabot.pkl
+++ b/packages/com.github.dependabot/v2/Dependabot.pkl
@@ -970,5 +970,17 @@ typealias ScheduleInterval =
   "daily" | "weekly" | "monthly" | "quarterly" | "semiannually" | "yearly" | "cron"
 
 output {
-  renderer = new YamlRenderer {}
+  renderer = new YamlRenderer {
+    converters {
+      // work around incorrect YAML parsing in Dependabot/Ruby/Psych
+      // https://github.com/apple/pkl/issues/1543
+      ["updates[*].schedule.time"] = (it) ->
+        if (it == null)
+          null
+        else
+          new RenderDirective {
+            text = " " + new JsonRenderer {}.renderValue(it)
+          }
+    }
+  }
 }

--- a/packages/pkl.github.dependabotManagedActions/PklProject
+++ b/packages/pkl.github.dependabotManagedActions/PklProject
@@ -21,7 +21,7 @@ amends "../basePklProject.pkl"
 import "DependabotManagedActions.pkl"
 
 package {
-  version = "1.1.0"
+  version = "1.1.1"
 }
 
 dependencies {

--- a/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
+++ b/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
@@ -13,7 +13,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.2",
       "path": "../com.github.dependabot"
     }
   }


### PR DESCRIPTION
Dependabot (which uses Ruby's stdlib YAML module) parses sexagesimal values with leading `0`s even though the YAML 1.1 spec does not accept these strings as numbers. Pkl's YAML renderer is compliant with YAML 1.1, so renders string values like `"04:00"` without quotes, causing Ruby/Dependabot to interpret the value as a number instead of string.

This PR forces JSON rendering of this specific field to avoid this upstream bug.

See https://github.com/apple/pkl/issues/1543