### PR TITLE
Enable Dependabot for Gradle, CodeQL scanning

### DIFF
--- a/.github/PklProject
+++ b/.github/PklProject
@@ -17,7 +17,7 @@ amends "pkl:Project"
 
 dependencies {
   ["pkl.impl.ghactions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0"
+    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.0"
   }
-  ["com.github.actions"] { uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.0" }
+  ["com.github.actions"] = import("../packages/com.github.actions/PklProject")
 }

--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": 1,
   "resolvedDependencies": {
-    "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
-      "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.1",
-      "checksums": {
-        "sha256": "fd515da685ea126678c3ec684e84a4f992d43481cc1d75cb866cd55775f675f9"
-      }
-    },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.0",
       "checksums": {
-        "sha256": "2c1e0d9efcd65b3c3207bf535c325ebc0ec2ab169187b324c4bb70821cac0e51"
+        "sha256": "962cdba703b50e86ecfda1a1345bf58caa7b4839dd090eae6120024d862793d0"
+      }
+    },
+    "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
+      "type": "remote",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0",
+      "checksums": {
+        "sha256": "10e27d63df4a4520d8a9375962406ca5ffe74f396bd3cb1c19b1f8358505010a"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -24,16 +24,16 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.3",
       "checksums": {
-        "sha256": "d368900942efb88ed51a98f9614748b06c74ba43423f045fcd6dedb5dbdc0bea"
+        "sha256": "521feb6f5ff12075ebad0758799fe7ec2675d231a0e0f5456694c8d4822a8171"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.3",
       "checksums": {
-        "sha256": "02ef6f25bfca5b1d095db73ea15de79d2d2c6832ebcab61e6aba90554382abcb"
+        "sha256": "a8934d84ffd11992d7baf6acfd97bae31d6112fa8add5cc8b5b4a722ce5b9ffc"
       }
     }
   }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
+- package-ecosystem: gradle
+  cooldown:
+    default-days: 7
+    exclude:
+    - org.pkl-lang:*
+  directory: /
+  schedule:
+    interval: weekly
 - package-ecosystem: github-actions
+  cooldown:
+    default-days: 7
   directory: /
   ignore:
   - dependency-name: '*'

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,6 +125,24 @@ main = (buildAndTest) {
       }
       needs {
         "build"
+      }
+    }
+  }
+}
+
+dependabot {
+  updates {
+    new {
+      `package-ecosystem` = "gradle"
+      directory = "/"
+      cooldown {
+        `default-days` = 7
+        exclude {
+          "org.pkl-lang:*"
+        }
+      }
+      schedule {
+        interval = "weekly"
       }
     }
   }

--- a/.github/workflows/__lockfile__.yml
+++ b/.github/workflows/__lockfile__.yml
@@ -30,3 +30,7 @@ jobs:
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     - name: dawidd6/action-download-artifact@v11
       uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+    - name: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+    - name: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+# Generated from Workflow.pkl. DO NOT EDIT.
+'on':
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+  schedule:
+  - cron: 29 17 * * 4
+jobs:
+  analyze-actions:
+    name: Analyze (actions)
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        languages: actions
+        build-mode: none
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        category: /language:actions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,17 +36,15 @@ plugins {
   alias(libs.plugins.spotless)
 }
 
+configurations { all { resolutionStrategy { failOnDynamicVersions() } } }
+
 class PklFormatterStep : Serializable {
   companion object {
     @Serial private const val serialVersionUID: Long = 1L
   }
 
   fun create(): FormatterStep {
-    return FormatterStep.createLazy(
-      "pkl",
-      { PklFormatterStep() },
-      { PklFormatterFunc() },
-    )
+    return FormatterStep.createLazy("pkl", { PklFormatterStep() }, { PklFormatterFunc() })
   }
 }
 
@@ -107,14 +105,13 @@ val ghaForkedFileLicense =
   // See the License for the specific language governing permissions and
   // limitations under the License.
   //===----------------------------------------------------------------------===//
-"""
+  """
     .trimIndent()
 
-@Suppress("CanConvertToMultiDollarString") // ktfmt can't
 val blockHeader =
-  """
+  $$"""
   /**
-   * Copyright © ${'$'}YEAR Apple Inc. and the Pkl project authors. All rights reserved.
+   * Copyright © $YEAR Apple Inc. and the Pkl project authors. All rights reserved.
    *
    * Licensed under the Apache License, Version 2.0 (the "License");
    * you may not use this file except in compliance with the License.
@@ -137,35 +134,35 @@ spotless {
   kotlin {
     licenseHeader(blockHeader)
     target("src/**/*.kt", "buildSrc/**/*.kt")
-    ktfmt().googleStyle()
+    ktfmt(libs.versions.ktfmt.get()).googleStyle()
   }
   kotlinGradle {
     licenseHeader(blockHeader, "([a-zA-Z]|@file|//)")
-    ktfmt().googleStyle()
+    ktfmt(libs.versions.ktfmt.get()).googleStyle()
     target("*.kts", "buildSrc/**/*.kts")
   }
   format("pkl") {
     val delimiter = "(/// |/\\*\\*|module |import |amends |(\\w+))"
     licenseHeader(
-        """
-            //===----------------------------------------------------------------------===//
-            // Copyright © ${'$'}YEAR Apple Inc. and the Pkl project authors. All rights reserved.
-            //
-            // Licensed under the Apache License, Version 2.0 (the "License");
-            // you may not use this file except in compliance with the License.
-            // You may obtain a copy of the License at
-            //
-            //     https://www.apache.org/licenses/LICENSE-2.0
-            //
-            // Unless required by applicable law or agreed to in writing, software
-            // distributed under the License is distributed on an "AS IS" BASIS,
-            // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            // See the License for the specific language governing permissions and
-            // limitations under the License.
-            //===----------------------------------------------------------------------===//
+        $$"""
+        //===----------------------------------------------------------------------===//
+        // Copyright © $YEAR Apple Inc. and the Pkl project authors. All rights reserved.
+        //
+        // Licensed under the Apache License, Version 2.0 (the "License");
+        // you may not use this file except in compliance with the License.
+        // You may obtain a copy of the License at
+        //
+        //     https://www.apache.org/licenses/LICENSE-2.0
+        //
+        // Unless required by applicable law or agreed to in writing, software
+        // distributed under the License is distributed on an "AS IS" BASIS,
+        // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        // See the License for the specific language governing permissions and
+        // limitations under the License.
+        //===----------------------------------------------------------------------===//
         """
           .trimIndent(),
-        delimiter
+        delimiter,
       )
       .named("base-license-header")
     licenseHeader(ghaForkedFileLicense, delimiter).named("pkl-gha").onlyIfContentMatches("gha-fork")
@@ -238,91 +235,89 @@ fun gatherDependentPackages(packageDirName: String): List<String> {
   }
 }
 
-val decorateFailureWithDependentPackageInformation by
-  tasks.registering {
-    onlyIf {
-      @Suppress("SENSELESS_COMPARISON")
-      createPackages.get().state.failure != null
-    }
-    doLast {
-      val createPackagesTask = createPackages.get()
-
-      @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-      val failureMessage = createPackagesTask.state.failure!!.cause?.message ?: return@doLast
-      if (!failureMessage.contains("was already published with different contents")) {
-        return@doLast
-      }
-      val packageName = Regex("`(.+)`").find(failureMessage)?.groups?.get(1)?.value ?: return@doLast
-      val dirName =
-        packageName
-          .drop("package://pkg.pkl-lang.org/pkl-pantry/".length)
-          .dropLastWhile { it != '@' }
-          .dropLast(1)
-      val dependentPackages = gatherDependentPackages(dirName)
-      if (dependentPackages.isEmpty()) {
-        return@doLast
-      }
-      val msg = buildString {
-        appendLine(
-          "The following packages depend on this package, and also need to have their version updated:"
-        )
-        for (pkgName in dependentPackages) {
-          appendLine("* $pkgName")
-        }
-      }
-      createPackagesTask.state.addFailure(
-        TaskExecutionException(createPackagesTask, RuntimeException(msg))
-      )
-    }
+val decorateFailureWithDependentPackageInformation by tasks.registering {
+  onlyIf {
+    @Suppress("SENSELESS_COMPARISON")
+    createPackages.get().state.failure != null
   }
+  doLast {
+    val createPackagesTask = createPackages.get()
+
+    @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
+    val failureMessage = createPackagesTask.state.failure!!.cause?.message ?: return@doLast
+    if (!failureMessage.contains("was already published with different contents")) {
+      return@doLast
+    }
+    val packageName = Regex("`(.+)`").find(failureMessage)?.groups?.get(1)?.value ?: return@doLast
+    val dirName =
+      packageName
+        .drop("package://pkg.pkl-lang.org/pkl-pantry/".length)
+        .dropLastWhile { it != '@' }
+        .dropLast(1)
+    val dependentPackages = gatherDependentPackages(dirName)
+    if (dependentPackages.isEmpty()) {
+      return@doLast
+    }
+    val msg = buildString {
+      appendLine(
+        "The following packages depend on this package, and also need to have their version updated:"
+      )
+      for (pkgName in dependentPackages) {
+        appendLine("* $pkgName")
+      }
+    }
+    createPackagesTask.state.addFailure(
+      TaskExecutionException(createPackagesTask, RuntimeException(msg))
+    )
+  }
+}
 
 createPackages.get().finalizedBy(decorateFailureWithDependentPackageInformation)
 
 repositories { mavenCentral() }
 
-val prepareReleases by
-  tasks.registering {
-    group = "build"
-    dependsOn(createPackages)
-    inputs.files(projectDirs)
+val prepareReleases by tasks.registering {
+  group = "build"
+  dependsOn(createPackages)
+  inputs.files(projectDirs)
 
-    doLast {
-      val releaseDir = file(outputDir.dir("releases"))
-      releaseDir.deleteRecursively()
-      val count = projectDirs.count()
-      val fmt = "%${ceil(log10(count.toDouble())).toInt()}d"
-      for (i in projectDirs.indices) {
-        val dir = projectDirs[i]
-        print(" [${fmt.format(i + 1)}/$count] $dir: ")
-        val allVersions = file(outputDir.dir("generated/packages/${dir.name}")).list()
-        if (allVersions == null) {
-          println("∅")
-          continue
-        }
-        val latestVersion = allVersions.map(Version::parse).sortedWith(Version.comparator()).last()
-        val pkg = "${dir.name}@$latestVersion"
-        print("$pkg: ")
-        val conn =
-          URI("${repositoryUrl}/releases/tag/${dir.name}@$latestVersion").toURL().openConnection()
-            as HttpsURLConnection
-        if (conn.responseCode == 200) {
-          println("⏩")
-          continue
-        }
-        val execProvider = providers.exec { commandLine("git", "tag", "-l", pkg) }
-        execProvider.result.get()
-        if (execProvider.standardOutput.asText.get().contains(pkg)) {
-          println("☑️")
-          continue
-        }
-        for (artifact in
-          file(outputDir.dir("generated/packages/${dir.name}/$latestVersion")).listFiles()!!) {
-          artifact.copyTo(releaseDir.resolve("$pkg/${artifact.name}"), true)
-        }
-        println("✅")
+  doLast {
+    val releaseDir = file(outputDir.dir("releases"))
+    releaseDir.deleteRecursively()
+    val count = projectDirs.count()
+    val fmt = "%${ceil(log10(count.toDouble())).toInt()}d"
+    for (i in projectDirs.indices) {
+      val dir = projectDirs[i]
+      print(" [${fmt.format(i + 1)}/$count] $dir: ")
+      val allVersions = file(outputDir.dir("generated/packages/${dir.name}")).list()
+      if (allVersions == null) {
+        println("∅")
+        continue
       }
+      val latestVersion = allVersions.map(Version::parse).sortedWith(Version.comparator()).last()
+      val pkg = "${dir.name}@$latestVersion"
+      print("$pkg: ")
+      val conn =
+        URI("${repositoryUrl}/releases/tag/${dir.name}@$latestVersion").toURL().openConnection()
+          as HttpsURLConnection
+      if (conn.responseCode == 200) {
+        println("⏩")
+        continue
+      }
+      val execProvider = providers.exec { commandLine("git", "tag", "-l", pkg) }
+      execProvider.result.get()
+      if (execProvider.standardOutput.asText.get().contains(pkg)) {
+        println("☑️")
+        continue
+      }
+      for (artifact in
+        file(outputDir.dir("generated/packages/${dir.name}/$latestVersion")).listFiles()!!) {
+        artifact.copyTo(releaseDir.resolve("$pkg/${artifact.name}"), true)
+      }
+      println("✅")
     }
   }
+}
 
 val testTarExamples by
   tasks.registering(Exec::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
-pkl = "0.31.+"
+pkl = "0.31.1"
+ktfmt = "0.62"
 kotlin = "2.2.20"
-junit = "5.+"
+junit = "6.0.3"
 spotless = "6.25.0"
-junitPlatformLauncher = "1.+"
+junitPlatformLauncher = "6.0.3"
 
 [libraries]
 junitEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }


### PR DESCRIPTION
Also:

* Fix versions of libraries (fixing ktfmt to 0.62 introduces formatting changes)
* Fail on dynamic Gradle versions
* Pin `com.github.actions` to the version locally within the pantry