### PR TITLE
[com.influxdata.telegraf] Add a few input plugins

### DIFF
--- a/packages/com.influxdata.telegraf/Inputs.pkl
+++ b/packages/com.influxdata.telegraf/Inputs.pkl
@@ -17,16 +17,23 @@ open module com.influxdata.telegraf.Inputs
 
 import "plugins/inputs/CpuInput.pkl"
 import "plugins/inputs/DiskInput.pkl"
+import "plugins/inputs/DiskioInput.pkl"
 import "plugins/inputs/DockerInput.pkl"
 import "plugins/inputs/ExecInput.pkl"
 import "plugins/inputs/FileInput.pkl"
 import "plugins/inputs/HttpInput.pkl"
 import "plugins/inputs/Jolokia2AgentInput.pkl"
+import "plugins/inputs/KernelInput.pkl"
+import "plugins/inputs/MemInput.pkl"
 import "plugins/inputs/NetInput.pkl"
 import "plugins/inputs/OpenTelemetry.pkl"
+import "plugins/inputs/ProcessesInput.pkl"
 import "plugins/inputs/PrometheusInput.pkl"
+import "plugins/inputs/RedisInput.pkl"
 import "plugins/inputs/SocketListenerInput.pkl"
 import "plugins/inputs/SolrInput.pkl"
+import "plugins/inputs/SwapInput.pkl"
+import "plugins/inputs/SystemInput.pkl"
 import "plugins/inputs/TailInput.pkl"
 import "plugins/inputs/X509CertInput.pkl"
 
@@ -96,6 +103,34 @@ x509_cert: Listing<X509CertInput>?
 /// [data formats](https://docs.influxdata.com/telegraf/v1/data_formats/input/).
 tail: Listing<TailInput>?
 
+/// The [DiskIO input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/diskio/)
+/// gathers metrics about disk I/O by device.
+diskio: Listing<DiskioInput>?
+
 /// The [Docker input plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/docker/README.md)
 /// uses the Docker Engine API to gather metrics on running Docker or Podman containers.
 docker: Listing<DockerInput>?
+
+/// The [Kernel input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/kernel/)
+/// gathers kernel statistics from `/proc/stat`.
+kernel: Listing<KernelInput>?
+
+/// The [Mem input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/mem/)
+/// collects metrics about memory usage.
+mem: Listing<MemInput>?
+
+/// The [Processes input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/processes/)
+/// gathers the number of processes and groups them by status.
+processes: Listing<ProcessesInput>?
+
+/// The [Swap input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/swap/)
+/// collects metrics about swap memory usage.
+swap: Listing<SwapInput>?
+
+/// The [System input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/system/)
+/// collects metrics about system load, uptime, and the number of logged-in users.
+system: Listing<SystemInput>?
+
+/// The [Redis input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/redis/)
+/// gathers metrics from [Redis](https://redis.io/) servers.
+redis: Listing<RedisInput>?

--- a/packages/com.influxdata.telegraf/examples/diskioInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/diskioInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+inputs {
+  diskio {
+    new {
+      devices {
+        "sda"
+        "sdb"
+        "vd*"
+      }
+      skip_serial_number = true
+      device_tags {
+        "ID_FS_TYPE"
+        "ID_FS_USAGE"
+      }
+      name_templates {
+        "$ID_FS_LABEL"
+        "$DM_VG_NAME/$DM_LV_NAME"
+      }
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/kernelInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/kernelInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+inputs {
+  kernel {
+    new {
+      collect {
+        "ksm"
+        "psi"
+      }
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/memInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/memInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+// The mem plugin has no options of its own; this exercises the fields common to
+// every input.
+inputs {
+  mem {
+    new {
+      interval = 30.s
+      tags {
+        ["host_role"] = "database"
+      }
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/processesInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/processesInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+inputs {
+  processes {
+    new {
+      use_sudo = true
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/redisInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/redisInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+inputs {
+  redis {
+    new {
+      servers {
+        "tcp://localhost:6379"
+        "unix:///var/run/redis.sock"
+      }
+      username = "telegraf"
+      password = "hunter2"
+      commands {
+        new {
+          command {
+            "get"
+            "sample-key"
+          }
+          field = "sample_key_value"
+          type = "string"
+        }
+      }
+      tls_ca = "/etc/telegraf/ca.pem"
+      tls_cert = "/etc/telegraf/cert.pem"
+      tls_key = "/etc/telegraf/key.pem"
+      insecure_skip_verify = true
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/swapInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/swapInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+// The swap plugin has no options of its own; this exercises the fields common to
+// every input.
+inputs {
+  swap {
+    new {
+      name_prefix = "host_"
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/examples/systemInput.pkl
+++ b/packages/com.influxdata.telegraf/examples/systemInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+amends "../Telegraf.pkl"
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
+// The system plugin has no options of its own. Drop the deprecated
+// `uptime_format` field using the filtering options common to every input.
+inputs {
+  system {
+    new {
+      fielddrop {
+        "uptime_format"
+      }
+    }
+  }
 }

--- a/packages/com.influxdata.telegraf/plugins/inputs/DiskioInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/DiskioInput.pkl
@@ -18,7 +18,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.DiskioInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 /// Devices to collect stats for.
 ///

--- a/packages/com.influxdata.telegraf/plugins/inputs/DiskioInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/DiskioInput.pkl
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// The [DiskIO input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/diskio/)
+/// gathers metrics about disk I/O by device.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.DiskioInput
+
+extends "./Input.pkl"
+
+/// Devices to collect stats for.
+///
+/// Wildcards are supported, except for disk synonyms like `/dev/disk/by-id/`.
+///
+/// Default: `["*"]` (all devices, including partitions)
+devices: Listing<String>?
+
+/// Skip gathering of the disk's serial numbers.
+skip_serial_number: Boolean?
+
+/// Device metadata to add as tags, on systems that support it (Linux only).
+/// Use 'udevadm info -q property -n <device>' to get a list of properties.
+/// Note: Most, but not all, udev properties can be accessed this way. Properties
+/// that are currently inaccessible include DEVTYPE, DEVNAME, and DEVPATH.
+device_tags: Listing<String>?
+
+/// Templates used to customize the device name tag.
+///
+/// Using the same metadata source as device_tags, you can also customize the
+/// name of the device via templates. The 'name_templates' parameter is a list
+/// of templates to try and apply to the device. The template may contain
+/// variables in the form of '$PROPERTY' or '${PROPERTY}'. The first template
+/// which does not contain any variables not present for the device is used as
+/// the device name tag. The typical use case is for LVM volumes, to get the
+/// VG/LV name instead of the near-meaningless DM-0 name.
+name_templates: Listing<String>?

--- a/packages/com.influxdata.telegraf/plugins/inputs/HttpInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/HttpInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 open module com.influxdata.telegraf.plugins.inputs.HttpInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 import "../parsers/InputDataFormat.pkl"
 

--- a/packages/com.influxdata.telegraf/plugins/inputs/KernelInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/KernelInput.pkl
@@ -20,7 +20,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.KernelInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 /// Additional metrics to gather beyond the standard kernel statistics.
 ///

--- a/packages/com.influxdata.telegraf/plugins/inputs/KernelInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/KernelInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+/// The [Kernel input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/kernel/)
+/// gathers kernel statistics from `/proc/stat`.
+///
+/// This plugin only supports Linux.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.KernelInput
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
+extends "./Input.pkl"
 
-package {
-  version = "1.8.0"
-}
+/// Additional metrics to gather beyond the standard kernel statistics.
+///
+/// Possible options:
+///
+/// - `"ksm"`: kernel same-page merging
+/// - `"psi"`: pressure stall information (requires kernel 4.20+)
+collect: Listing<"ksm" | "psi">?

--- a/packages/com.influxdata.telegraf/plugins/inputs/MemInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/MemInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+/// The [Mem input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/mem/)
+/// collects metrics about memory usage.
+///
+/// This plugin has no configuration beyond the options common to every input.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.MemInput
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
-}
+extends "./Input.pkl"

--- a/packages/com.influxdata.telegraf/plugins/inputs/MemInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/MemInput.pkl
@@ -20,4 +20,4 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.MemInput
 
-extends "./Input.pkl"
+extends "Input.pkl"

--- a/packages/com.influxdata.telegraf/plugins/inputs/ProcessesInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/ProcessesInput.pkl
@@ -20,7 +20,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.ProcessesInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 /// Use `sudo` to run the `ps` command on \*BSD systems.
 ///

--- a/packages/com.influxdata.telegraf/plugins/inputs/ProcessesInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/ProcessesInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+/// The [Processes input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/processes/)
+/// gathers the number of processes and groups them by status.
+///
+/// This plugin only supports non-Windows systems.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.ProcessesInput
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
+extends "./Input.pkl"
 
-package {
-  version = "1.8.0"
-}
+/// Use `sudo` to run the `ps` command on \*BSD systems.
+///
+/// Linux systems read `/proc`, so this does not apply there.
+use_sudo: Boolean?

--- a/packages/com.influxdata.telegraf/plugins/inputs/RedisInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/RedisInput.pkl
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+/// The [Redis input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/redis/)
+/// gathers metrics from [Redis](https://redis.io/) servers.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.RedisInput
+
+extends "./Input.pkl"
+
+/// One or more URLs of Redis servers, matching the pattern
+/// `[protocol://][username:password]@address[:port]`, for example:
+///
+/// - `tcp://localhost:6379`
+/// - `tcp://username:password@192.168.99.100`
+/// - `unix:///var/run/redis.sock`
+///
+/// If no servers are specified, then `localhost` is used as the host.
+/// If no port is specified, `6379` is used.
+servers: Listing<String>?
+
+/// Optional Redis commands to retrieve additional values.
+commands: Listing<Command>?
+
+/// Username for ACL authentication (Redis 6.0+). You can add this
+/// to the server URI above or specify it here. The values here take
+/// precedence.
+username: String?
+
+/// Password for ACL authentication (Redis 6.0+). You can add this
+/// to the server URI above or specify it here. The values here take
+/// precedence.
+password: String?
+
+/// Optional TLS Config.
+tls_ca: String?
+tls_cert: String?
+tls_key: String?
+
+/// Use TLS but skip chain & host verification.
+insecure_skip_verify: Boolean?
+
+/// A Redis command whose result is stored in a field.
+class Command {
+  /// The command to send to the Redis server, given as the command name
+  /// followed by its arguments.
+  ///
+  /// For example, `new { "get"; "sample-key" }`.
+  command: Listing<String>
+
+  /// The field to store the result in.
+  field: String
+
+  /// The type of the result.
+  type: "string" | "integer" | "float"
+}

--- a/packages/com.influxdata.telegraf/plugins/inputs/RedisInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/RedisInput.pkl
@@ -18,7 +18,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.RedisInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 /// One or more URLs of Redis servers, matching the pattern
 /// `[protocol://][username:password]@address[:port]`, for example:

--- a/packages/com.influxdata.telegraf/plugins/inputs/SolrInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/SolrInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 open module com.influxdata.telegraf.plugins.inputs.SolrInput
 
-extends "./Input.pkl"
+extends "Input.pkl"
 
 /// One or more URLs of Solr servers
 servers: Listing<String>(!isEmpty)

--- a/packages/com.influxdata.telegraf/plugins/inputs/SwapInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/SwapInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+/// The [Swap input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/swap/)
+/// collects metrics about swap memory usage.
+///
+/// This plugin has no configuration beyond the options common to every input.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.SwapInput
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
-}
+extends "./Input.pkl"

--- a/packages/com.influxdata.telegraf/plugins/inputs/SwapInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/SwapInput.pkl
@@ -20,4 +20,4 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.SwapInput
 
-extends "./Input.pkl"
+extends "Input.pkl"

--- a/packages/com.influxdata.telegraf/plugins/inputs/SystemInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/SystemInput.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //===----------------------------------------------------------------------===//
-/// Templates for configuring [Telegraf](https://docs.influxdata.com/telegraf),
-/// a plugin-driven server agent for collecting and reporting metrics.
-amends "../basePklProject.pkl"
+/// The [System input plugin](https://docs.influxdata.com/telegraf/v1/input-plugins/system/)
+/// collects metrics about system load, uptime, and the number of logged-in users.
+///
+/// This plugin has no configuration beyond the options common to every input.
+/// The deprecated `uptime_format` field can be removed with `fielddrop = new { "uptime_format" }`.
+@ModuleInfo { minPklVersion = "0.25.0" }
+module com.influxdata.telegraf.plugins.inputs.SystemInput
 
-dependencies {
-  ["toml"] = import("../pkl.toml/PklProject")
-}
-
-package {
-  version = "1.8.0"
-}
+extends "./Input.pkl"

--- a/packages/com.influxdata.telegraf/plugins/inputs/SystemInput.pkl
+++ b/packages/com.influxdata.telegraf/plugins/inputs/SystemInput.pkl
@@ -21,4 +21,4 @@
 @ModuleInfo { minPklVersion = "0.25.0" }
 module com.influxdata.telegraf.plugins.inputs.SystemInput
 
-extends "./Input.pkl"
+extends "Input.pkl"

--- a/packages/com.influxdata.telegraf/tests/Telegraf.pkl-expected.pcf
+++ b/packages/com.influxdata.telegraf/tests/Telegraf.pkl-expected.pcf
@@ -20,6 +20,15 @@ examples {
     paths = [ "Uptime" ]
     """
   }
+  ["diskioInput.toml"] {
+    """
+    [[inputs.diskio]]
+    devices = [ "sda", "sdb", "vd*" ]
+    skip_serial_number = true
+    device_tags = [ "ID_FS_TYPE", "ID_FS_USAGE" ]
+    name_templates = [ "$ID_FS_LABEL", "$DM_VG_NAME/$DM_LV_NAME" ]
+    """
+  }
   ["dockerInput.toml"] {
     """
     [[inputs.docker]]
@@ -41,6 +50,21 @@ examples {
     tls_cert = "/etc/telegraf/cert.pem"
     tls_key = "/etc/telegraf/key.pem"
     insecure_skip_verify = false
+    """
+  }
+  ["kernelInput.toml"] {
+    """
+    [[inputs.kernel]]
+    collect = [ "ksm", "psi" ]
+    """
+  }
+  ["memInput.toml"] {
+    """
+    [[inputs.mem]]
+    interval = "30s"
+    
+    [inputs.mem.tags]
+    host_role = "database"
     """
   }
   ["opentelemetry-output.toml"] {
@@ -67,6 +91,29 @@ examples {
     x-api-key = "my-api-key"
     """
   }
+  ["processesInput.toml"] {
+    """
+    [[inputs.processes]]
+    use_sudo = true
+    """
+  }
+  ["redisInput.toml"] {
+    """
+    [[inputs.redis]]
+    servers = [ "tcp://localhost:6379", "unix:///var/run/redis.sock" ]
+    username = "telegraf"
+    password = "hunter2"
+    tls_ca = "/etc/telegraf/ca.pem"
+    tls_cert = "/etc/telegraf/cert.pem"
+    tls_key = "/etc/telegraf/key.pem"
+    insecure_skip_verify = true
+    
+    [[inputs.redis.commands]]
+    command = [ "get", "sample-key" ]
+    field = "sample_key_value"
+    type = "string"
+    """
+  }
   ["simple.toml"] {
     """
     [[outputs.file]]
@@ -88,6 +135,18 @@ examples {
     
     [global_tags]
     user = "alice"
+    """
+  }
+  ["swapInput.toml"] {
+    """
+    [[inputs.swap]]
+    name_prefix = "host_"
+    """
+  }
+  ["systemInput.toml"] {
+    """
+    [[inputs.system]]
+    fielddrop = [ "uptime_format" ]
     """
   }
   ["x509CertInput.toml"] {


### PR DESCRIPTION
Hi!

This is pull request that adds a few of the simpler input plugins for Telegraf.
* diskio
* kernel
* mem
* processes
* redis
* swap
* system

I'm on the fence about two things :
* Should I split this commit in multiple commits and/or PRs?
* I looked at the existing plugins, some were `open modules` and some were closed. I decided to `open` those that were non-trivial to let the user add configurations that could be out of sync. Maybe I should `open` all of them instead?

Thank you