### PR TITLE
Bug fix for when a non-nullable property is missing

### DIFF
--- a/packages/com.github.actions.contrib/PklProject
+++ b/packages/com.github.actions.contrib/PklProject
@@ -24,5 +24,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.15"
+  version = "1.0.16"
 }

--- a/packages/com.github.actions.contrib/PklProject.deps.json
+++ b/packages/com.github.actions.contrib/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {

--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "4.2.1"
+  version = "4.2.2"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -10,7 +10,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {

--- a/packages/pkl.experimental.deepToTyped/PklProject
+++ b/packages/pkl.experimental.deepToTyped/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.2.0"
+  version = "1.2.1"
 }

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -175,7 +175,9 @@ local function applyProperty(valueAsMap: Map, prop: reflect.Property) =
     else if (prop.defaultValue != null)
       prop.defaultValue
     else
-      Fail("missing \(if (prop.type is reflect.DeclaredType) prop.type.referent.name else "Unknown")")
+      Fail(
+        "missing \(if (prop.type is reflect.DeclaredType) prop.type.referent.name else "Unknown")"
+      )
 
 local function applyDynamicOrMapping(
   type: reflect.Class,

--- a/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/deepToTyped.pkl
@@ -170,10 +170,12 @@ local function applyProperty(valueAsMap: Map, prop: reflect.Property) =
   )
     if (valueAsMap.containsKey(propName))
       applyType(prop.type, valueAsMap[propName])
-    else if (!(prop.type is reflect.NullableType) && prop.defaultValue != null)
+    else if (prop.type is reflect.NullableType)
+      null
+    else if (prop.defaultValue != null)
       prop.defaultValue
     else
-      null
+      Fail("missing \(if (prop.type is reflect.DeclaredType) prop.type.referent.name else "Unknown")")
 
 local function applyDynamicOrMapping(
   type: reflect.Class,

--- a/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
+++ b/packages/pkl.experimental.deepToTyped/tests/deepToTyped.pkl
@@ -356,4 +356,10 @@ facts {
       keyTransform = (prop) -> prop.annotations.findOrNull((it) -> it is KeyTransform)?.name
     }.apply(ClassWithKeyTranform, input) == expectedClassWithKeyTranform
   }
+
+  ["deepToTyped.attemptApply() missing field does not throw"] {
+    // Foo requires the x field to be defined. This should return
+    // a converstion failure and **not** throw an error
+    t.attemptApply(Foo, new Mapping {}) is t.ConversionFailure
+  }
 }

--- a/packages/pkl.experimental.structuredRead/PklProject
+++ b/packages/pkl.experimental.structuredRead/PklProject
@@ -16,7 +16,7 @@
 amends ".../basePklProject.pkl"
 
 package {
-  version = "1.0.5"
+  version = "1.0.6"
 }
 
 dependencies {

--- a/packages/pkl.experimental.structuredRead/PklProject.deps.json
+++ b/packages/pkl.experimental.structuredRead/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1",
       "path": "../pkl.experimental.deepToTyped"
     }
   }

--- a/packages/pkl.github.dependabotManagedActions/PklProject
+++ b/packages/pkl.github.dependabotManagedActions/PklProject
@@ -21,7 +21,7 @@ amends "../basePklProject.pkl"
 import "DependabotManagedActions.pkl"
 
 package {
-  version = "1.1.8"
+  version = "1.1.9"
 }
 
 dependencies {

--- a/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
+++ b/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1",
       "path": "../pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {

--- a/scripts/PklProject.deps.json
+++ b/scripts/PklProject.deps.json
@@ -8,7 +8,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1.2.1",
       "path": "../packages/pkl.experimental.deepToTyped"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {


### PR DESCRIPTION
Without this change, `deepToTyped.attemptApply()` will throw an error if a field is missing that is not marked as nullable when it should be returning a `ConversionFailure` and not throwing.