### PR TITLE
Fix dependabot cooldown exclusion for `org.pkl-lang`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   cooldown:
     default-days: 7
     exclude:
-    - org.pkl-lang:*
+    - org.pkl-lang
   directory: /
   schedule:
-    interval: weekly
+    interval: quarterly
 - package-ecosystem: github-actions
   cooldown:
     default-days: 7

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -138,11 +138,11 @@ dependabot {
       cooldown {
         `default-days` = 7
         exclude {
-          "org.pkl-lang:*"
+          "org.pkl-lang"
         }
       }
       schedule {
-        interval = "weekly"
+        interval = "quarterly"
       }
     }
   }


### PR DESCRIPTION
The `exclude` currently isn't working as intended:
```
updater | 2026/07/09 08:23:55 INFO <job_1453436650> Parsed Gradle Plugin Portal release for org.pkl-lang: 0.32.0 at 2026-07-08 17:40:54 +0000
2026/07/09 08:23:56 [056] 200 https://repo.maven.apache.org:443/maven2/org/pkl-lang/org.pkl-lang.gradle.plugin/ (cached)
updater | 2026/07/09 08:23:56 INFO <job_1453436650> Initializing cooldown filter
updater | 2026/07/09 08:23:56 INFO <job_1453436650> Version 0.32.0, Release date: 2026-07-08 17:40:54 +0000. Days since release: 0 (cooldown days: 7)
updater | 2026/07/09 08:23:56 INFO <job_1453436650> Filtered out (cooldown) : 0.32.0
updater | 2026/07/09 08:23:56 INFO <job_1453436650> Version 0.32.0, Release date: 2026-07-08 17:40:54 +0000. Days since release: 0 (cooldown days: 7)
2026/07/09 08:23:56 INFO <job_1453436650> Filtered out (cooldown) : 0.32.0
updater | 2026/07/09 08:23:56 INFO <job_1453436650> Filtered out 2 version(s) due to cooldown
```