### PR TITLE
Add method to compute nth subnet

### DIFF
--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -341,12 +341,29 @@ class IPv4Network {
   function reverse(): String = base.toString().split(".").take(prefix ~/ reverseBitResolution).reverse().join(".") + ".in-addr.arpa"
 
   /// Calculate all subnets of this network with prefix [target].
+  ///
   /// For example, given IPv4Network("10.53.120.0/21").subdivideTo(24), it outputs 8 /24 networks
+  ///
+  /// Note: this enumerates all subnets eagerly. If the target prefix is much larger than this
+  /// network's prefix, this can take a long time! See [subnet()] for a way to compute a single
+  /// subnet.
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv4Network> =
     if (prefix == target) new { self }
     else new {
       ...new IPv4Network { base = self.base; prefix = self.prefix + 1 }.subdivideTo(target)
       ...new IPv4Network { base = new { repr = self.base.repr + 1.shl(bitWidth - self.prefix - 1) }; prefix = self.prefix + 1 }.subdivideTo(target)
+    }
+
+  /// Compute the [n]th subnet of this network with prefix [target].
+  ///
+  /// For example, given `IPv4Network("10.53.120.0/21").subnet(24, 3)`, it outputs
+  /// `IPv4Network("10.53.123.0/24")`.
+  function subnet(target: UInt(isBetween(0, bitWidth) && this >= prefix), n: UInt32): net.IPv4Network =
+    if (1.shl(target - prefix) <= n)
+      throw("subnet number \(n) exceeds maximum possible between prefix /\(prefix) and target /\(target)")
+    else new net.IPv4Network {
+      base = new net.IPv4Address { repr = firstAddress.repr + n.shl(bitWidth - target) }
+      prefix = target
     }
 
   function toString(): String = "\(base.toString())/\(prefix)"
@@ -400,11 +417,31 @@ class IPv6Network {
   /// Calculate all subnets of this network with prefix [target].
   ///
   /// For example, given `IPv6Network("2620:149:a:960::/61").subdivideTo(64)`, it outputs 8 /64 networks
+  ///
+  /// Note: this enumerates all subnets eagerly. If the target prefix is much larger than this
+  /// network's prefix, this can take a long time! See [subnet()] for a way to compute a single
+  /// subnet.
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv6Network> =
     if (prefix == target) new { self }
     else new {
       ...(self) { prefix = self.prefix + 1 }.subdivideTo(target)
       ...(self) { base { repr = self.base.repr.add(u128.one.shl(bitWidth - self.prefix - 1)) }; prefix = self.prefix + 1 }.subdivideTo(target)
+    }
+
+  /// Compute the [n]th subnet of this network with prefix [target].
+  ///
+  /// For example, given `IPv6Network("2620:149:a:960::/64").subnet(80, 10)`, it outputs
+  /// `IPv6Network("2620:149:a:960:a::/80")`.
+  function subnet(target: UInt(isBetween(0, bitWidth) && this >= prefix), n: UInt32): net.IPv6Network =
+    // `target - prefix == bitWidth` (only possible when prefix == 0 and target == bitWidth) is skipped:
+    // the true subnet count, 2^bitWidth, isn't representable as a UInt128, and shl() wraps around to 0
+    // in that case. The check is safe to skip here since n is a UInt32, always < 2^bitWidth.
+    if (target - prefix < bitWidth && u128.one.shl(target - prefix).le(u128.UInt128(0, 0, 0, n)))
+      throw("subnet number \(n) exceeds maximum possible between prefix /\(prefix) and target /\(target)")
+    else new net.IPv6Network {
+      local delta: u128.UInt128 = (u128.UInt128(0, 0, 0, n)).shl(bitWidth - target)
+      base = (firstAddress) { repr = firstAddress.repr.add(delta) }
+      prefix = target
     }
 
   function toString(): String = "\(base)/\(prefix)"

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -410,6 +410,47 @@ facts {
     net.IPv6Network("fe80::/64").firstAddress.scopeId == null
     net.IPv6Network("fe80::/64").lastAddress.scopeId == null
   }
+  ["IPv4Network.subnet()"] {
+    net.IPv4Network("10.53.120.0/21").subnet(24, 3) == net.IPv4Network("10.53.123.0/24")
+    net.IPv4Network("10.53.120.0/21").subnet(24, 0) == net.IPv4Network("10.53.120.0/24")
+    net.IPv4Network("10.53.120.0/21").subnet(24, 7) == net.IPv4Network("10.53.127.0/24") // last valid subnet
+    net.IPv4Network("10.53.120.0/21").subnet(21, 0) == net.IPv4Network("10.53.120.0/21") // target == prefix
+    module.catch(() -> net.IPv4Network("10.53.120.0/21").subnet(24, 8)) != null // one past the last valid subnet
+  }
+  ["IPv4Network.subnet() at the top of the address space (/32)"] {
+    // subdividing all the way down to individual hosts, right at the last IP in the address space
+    net.IPv4Network("255.255.255.252/30").subnet(32, 3) == net.IPv4Network("255.255.255.255/32")
+    // self is already a single-host (/32) network
+    net.IPv4Network("10.0.0.1/32").subnet(32, 0) == net.IPv4Network("10.0.0.1/32")
+    module.catch(() -> net.IPv4Network("10.0.0.1/32").subnet(32, 1)) != null
+    // target - prefix == bitWidth: subdividing the entire address space (/0) down to /32 hosts
+    net.IPv4Network("0.0.0.0/0").subnet(32, 0) == net.IPv4Network("0.0.0.0/32")
+    net.IPv4Network("0.0.0.0/0").subnet(32, 4294967295) == net.IPv4Network("255.255.255.255/32")
+  }
+  ["IPv6Network.subnet()"] {
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 10) == net.IPv6Network("2620:149:a:960:a::/80")
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 0) == net.IPv6Network("2620:149:a:960::/80")
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 65535) == net.IPv6Network("2620:149:a:960:ffff::/80") // last valid subnet
+    net.IPv6Network("2620:149:a:960::/64").subnet(64, 0) == net.IPv6Network("2620:149:a:960::/64") // target == prefix
+    module.catch(() -> net.IPv6Network("2620:149:a:960::/64").subnet(80, 65536)) != null // one past the last valid subnet
+  }
+  ["IPv6Network.subnet() at the top of the address space (/128)"] {
+    // subdividing all the way down to individual hosts, right at the last IP in the address space
+    net.IPv6Network("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/126").subnet(128, 3) ==
+      net.IPv6Network("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128")
+    // self is already a single-host (/128) network
+    net.IPv6Network("::1/128").subnet(128, 0) == net.IPv6Network("::1/128")
+    module.catch(() -> net.IPv6Network("::1/128").subnet(128, 1)) != null
+    // target - prefix == bitWidth: subdividing the entire address space (/0) down to /128 hosts.
+    // 2^128 isn't representable as a UInt128, so this exercises the fallback path that skips the
+    // (otherwise-overflowing) bounds check.
+    net.IPv6Network("::/0").subnet(128, 0) == net.IPv6Network("::/128")
+    net.IPv6Network("::/0").subnet(128, 4294967295) == net.IPv6Network("::ffff:ffff/128")
+  }
+  ["IPv6Network.subnet() preserves scopeId"] {
+    net.IPv6Network("fe80::%1/64").subnet(80, 10).base.scopeId == 1
+    net.IPv6Network("fe80::/64").subnet(80, 10).base.scopeId == null
+  }
   ["IPv6Range() preserves scopeId as appropriate"] {
     net.IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%1")).toList().every((ip) -> ip.scopeId == 1)
     net.IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%2")).toList().every((ip) -> ip.scopeId == null)


### PR DESCRIPTION
This adds a method to directly compute a subnet based on a target prefix and subnet number. The current way to do this is to call `subdivideTo()` which enumerates all subnets, and then take the desired one. While this works in theory, for large prefix differences this leads to many computations. In IPv6 especially, this can cause issues.