### PR TITLE
Add typealias to represent networks in strict notation

### DIFF
--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -94,6 +94,9 @@ typealias IPAddressPortString = IPv4AddressPortString|IPv6AddressPortString
 /// A string that contains either an IPv4 or IPv6 CIDR range.
 typealias IPCIDRString = IPv4CIDRString|IPv6CIDRString
 
+/// A string that contains either a IPv4 of IPv6 network.
+typealias IPNetworkString = IPv4NetworkString|IPv6NetworkString
+
 /// An IPv4 or IPv6 address.
 typealias IPAddress = IPv4Address|IPv6Address
 
@@ -127,6 +130,18 @@ typealias IPv4CIDRString = String(matches(Regex(#"\#(net.ipv4String)/[0-9]{1,2}"
 /// A string that contains an IPv6 address.
 // language=RegExp
 typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/[0-9]{1,3}"#)))
+
+/// A string that contains a strict IPv4 network, i.e. an IPv4 CIDR block whose address has no bits
+/// set beyond its prefix.
+///
+/// For example, `"10.0.0.0/24"` qualifies, but `"10.0.0.1/24"` does not, since the latter has host bits set.
+typealias IPv4NetworkString = String(this is IPv4CIDRString && let (n = net.IPv4Network(this)) n.base == n.firstAddress)
+
+/// A string that contains a strict IPv6 network, i.e. an IPv6 CIDR block whose address has no bits
+/// set beyond its prefix.
+///
+/// For example, `"2001:db8::/32"` qualifies, but `"2001:db8::1/32"` does not, since the latter has host bits set.
+typealias IPv6NetworkString = String(this is IPv6CIDRString && let (n = net.IPv6Network(this)) n.base == n.firstAddress)
 
 /// Creates an [IPAddress] from an [IPAddressString].
 function IP(ip: IPAddressString): IPAddress =

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -281,6 +281,33 @@ facts {
     !("" is net.IPv6CIDRString)
     !("0.0.0.0/10" is net.IPv6CIDRString)
   }
+  ["IPv4NetworkString"] {
+    "10.0.0.0/24" is net.IPv4NetworkString
+    "0.0.0.0/0" is net.IPv4NetworkString // whole address space: no host bits to be non-zero
+    "255.255.255.255/32" is net.IPv4NetworkString // single host: every bit is a network bit
+    !("10.0.0.1/24" is net.IPv4NetworkString) // host bits set
+    !("not a cidr" is net.IPv4NetworkString)
+    !("" is net.IPv4NetworkString)
+  }
+  ["IPv6NetworkString"] {
+    "2001:db8::/32" is net.IPv6NetworkString
+    "::/0" is net.IPv6NetworkString // whole address space: no host bits to be non-zero
+    "::1/128" is net.IPv6NetworkString // single host: every bit is a network bit
+    "fe80::%1/64" is net.IPv6NetworkString // scoped, but still canonical
+    !("2001:db8::1/32" is net.IPv6NetworkString) // host bits set
+    !("fe80::1/64" is net.IPv6NetworkString) // host bits set
+    !("fe80::1%1/64" is net.IPv6NetworkString) // scoped, host bits set
+    !("not a cidr" is net.IPv6NetworkString)
+    !("" is net.IPv6NetworkString)
+  }
+  ["IPNetworkString"] {
+    "10.0.0.0/24" is net.IPNetworkString
+    "2001:db8::/32" is net.IPNetworkString
+    !("10.0.0.1/24" is net.IPNetworkString) // host bits set
+    !("2001:db8::1/32" is net.IPNetworkString) // host bits set
+    !("not a cidr" is net.IPNetworkString)
+    !("" is net.IPNetworkString)
+  }
   ["IPv4AddressPortString"] {
     "0.0.0.0:0" is net.IPv4AddressPortString
     "255.255.255.255:65535" is net.IPv4AddressPortString


### PR DESCRIPTION
These type aliases require that only the prefix bit of the CIDR notation be set, and all host bits be zero. This is mainly done to enforce style in network configuration but can also help catch errors early.