### PR TITLE
net: subnet helpers

### DIFF
--- a/packages/pkl.experimental.net/PklProject
+++ b/packages/pkl.experimental.net/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.2.1"
+  version = "1.3.0"
 }

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -374,7 +374,12 @@ class IPv4Network {
       + ".in-addr.arpa"
 
   /// Calculate all subnets of this network with prefix [target].
+  ///
   /// For example, given IPv4Network("10.53.120.0/21").subdivideTo(24), it outputs 8 /24 networks
+  ///
+  /// Note: this enumerates all subnets eagerly. If the target prefix is much larger than this
+  /// network's prefix, this can take a long time! See [subnet()] for a way to compute a single
+  /// subnet.
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv4Network> =
     if (prefix == target)
       new { self }
@@ -385,6 +390,24 @@ class IPv4Network {
           base = new { repr = self.base.repr + 1.shl(bitWidth - self.prefix - 1) }
           prefix = self.prefix + 1
         }.subdivideTo(target)
+      }
+
+  /// Compute the [n]th subnet of this network with prefix [target].
+  ///
+  /// For example, given `IPv4Network("10.53.120.0/21").subnet(24, 3)`, it outputs
+  /// `IPv4Network("10.53.123.0/24")`.
+  function subnet(
+    target: UInt(isBetween(0, bitWidth) && this >= prefix),
+    n: UInt32
+  ): net.IPv4Network =
+    if (1.shl(target - prefix) <= n)
+      throw(
+        "subnet number \(n) exceeds maximum possible between prefix /\(prefix) and target /\(target)"
+      )
+    else
+      new net.IPv4Network {
+        base = new net.IPv4Address { repr = firstAddress.repr + n.shl(bitWidth - target) }
+        prefix = target
       }
 
   function toString(): String = "\(base.toString())/\(prefix)"
@@ -447,6 +470,10 @@ class IPv6Network {
   /// Calculate all subnets of this network with prefix [target].
   ///
   /// For example, given `IPv6Network("2620:149:a:960::/61").subdivideTo(64)`, it outputs 8 /64 networks
+  ///
+  /// Note: this enumerates all subnets eagerly. If the target prefix is much larger than this
+  /// network's prefix, this can take a long time! See [subnet()] for a way to compute a single
+  /// subnet.
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv6Network> =
     if (prefix == target)
       new { self }
@@ -457,6 +484,28 @@ class IPv6Network {
           base { repr = self.base.repr.add(u128.one.shl(bitWidth - self.prefix - 1)) }
           prefix = self.prefix + 1
         }.subdivideTo(target)
+      }
+
+  /// Compute the [n]th subnet of this network with prefix [target].
+  ///
+  /// For example, given `IPv6Network("2620:149:a:960::/64").subnet(80, 10)`, it outputs
+  /// `IPv6Network("2620:149:a:960:a::/80")`.
+  function subnet(
+    target: UInt(isBetween(0, bitWidth) && this >= prefix),
+    n: UInt32
+  ): net.IPv6Network =
+    // `target - prefix == bitWidth` (only possible when prefix == 0 and target == bitWidth) is skipped:
+    // the true subnet count, 2^bitWidth, isn't representable as a UInt128, and shl() wraps around to 0
+    // in that case. The check is safe to skip here since n is a UInt32, always < 2^bitWidth.
+    if (target - prefix < bitWidth && u128.one.shl(target - prefix).le(u128.UInt128(0, 0, 0, n)))
+      throw(
+        "subnet number \(n) exceeds maximum possible between prefix /\(prefix) and target /\(target)"
+      )
+    else
+      new net.IPv6Network {
+        local delta: u128.UInt128 = (u128.UInt128(0, 0, 0, n)).shl(bitWidth - target)
+        base = (firstAddress) { repr = firstAddress.repr.add(delta) }
+        prefix = target
       }
 
   function toString(): String = "\(base)/\(prefix)"

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -390,8 +390,7 @@ class IPv4Network {
   function containsNetwork(other: IPv4Network): Boolean =
     prefix <= other.prefix && firstAddress.repr == other.base.repr.and(other.base.maskHi(prefix))
 
-  /// Return true if this network overlaps with the other, i.e. either [other] is a subnet of this
-  /// network or vice versa.
+  /// Return true [other] is a subnet of this network or vice versa.
   function overlaps(other: IPv4Network): Boolean =
     self.containsNetwork(other) || other.containsNetwork(self)
 
@@ -491,8 +490,7 @@ class IPv6Network {
       && firstAddress.repr == other.base.repr.and(other.base.maskHi(prefix))
       && (base.scopeId == other.base.scopeId || base.scopeId == null || other.base.scopeId == null)
 
-  /// Return true if this network overlaps with the other, i.e. either [other] is a subnet of this
-  /// network or vice versa.
+  /// Return true [other] is a subnet of this network or vice versa.
   ///
   /// If both [base.scopeId][IPv6Address.scopeId] and [other.base.scopeId][IPv6Address.scopeId] are non-[null],
   /// they must match. If either is [null] then scope ID is ignored.

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -368,6 +368,14 @@ class IPv4Network {
   function contains(ip: IPv4Address): Boolean =
     firstAddress.repr <= ip.repr && ip.repr <= lastAddress.repr
 
+  /// Return true if [other] is a subnet of this network, i.e. every address in [other] is also in this network.
+  function containsNetwork(other: IPv4Network): Boolean =
+    self.contains(other.firstAddress) && self.contains(other.lastAddress)
+
+  /// Return true if this network and [other] share at least one address.
+  function overlaps(other: IPv4Network): Boolean =
+    self.containsNetwork(other) || other.containsNetwork(self)
+
   /// Generate the name of the reverse DNS zone for this network.
   function reverse(): String =
     base.toString().split(".").take(prefix ~/ reverseBitResolution).reverse().join(".")
@@ -456,6 +464,20 @@ class IPv6Network {
     firstAddress.repr.le(ip.repr)
       && ip.repr.le(lastAddress.repr)
       && (base.scopeId == ip.scopeId || base.scopeId == null || ip.scopeId == null)
+
+  /// Return true if [other] is a subnet of this network, i.e. every address in [other] is also in this network.
+  ///
+  /// If both [base.scopeId][IPv6Address.scopeId] and [other.base.scopeId][IPv6Address.scopeId] are non-[null],
+  /// they must match. If either is [null] then scope ID is ignored.
+  function containsNetwork(other: IPv6Network): Boolean =
+    self.contains(other.firstAddress) && self.contains(other.lastAddress)
+
+  /// Return true if this network and [other] share at least one address.
+  ///
+  /// If both [base.scopeId][IPv6Address.scopeId] and [other.base.scopeId][IPv6Address.scopeId] are non-[null],
+  /// they must match. If either is [null] then scope ID is ignored.
+  function overlaps(other: IPv6Network): Boolean =
+    self.containsNetwork(other) || other.containsNetwork(self)
 
   /// Generate the name of the reverse DNS zone for this network.
   function reverse(): String =

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,20 +19,22 @@
 module pkl.experimental.net.net
 
 import "pkl:math"
-import "./u128.pkl"
+
 import "./net.pkl"
+import "./u128.pkl"
 
 // language=RegExp
-const hidden hex: String = "[0-9a-fA-F]"
+hidden const hex: String = "[0-9a-fA-F]"
 
 // language=RegExp
-const hidden decByte: String = #"(25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})"#
+hidden const decByte: String = #"(25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})"#
 
 // language=RegExp
-const hidden ipv4String = #"(\#(decByte)\.){3}\#(decByte)"#
+hidden const ipv4String = #"(\#(decByte)\.){3}\#(decByte)"#
 
 // language=RegExp
-const hidden ipv6String = #"""
+hidden const ipv6String =
+  #"""
   (?x:
     (\#(hex){1,4}:){7}\#(hex){1,4}           # x:x:x:x:x:x:x:x
   | (\#(hex){1,4}:){1,7}:                    # x:: … x:x:x:x:x:x:x::
@@ -57,7 +59,8 @@ const hidden ipv6String = #"""
   """#
 
 // language=RegExp
-const hidden nonGlobalIPv6String = #"""
+hidden const nonGlobalIPv6String =
+  #"""
   (?xi-U:
     ff[0-9a-f][0-9a-d](?:                        # multicast (FF00::/8 with "scop" less than E (global scope))
       (:[0-9a-f]{1,4}){7}                        # FFxx:x:x:x:x:x:x:x
@@ -81,24 +84,25 @@ const hidden nonGlobalIPv6String = #"""
   )
   """#
 
-///	A string that contains a MAC address
+/// 	A string that contains a MAC address
 // language=RegExp
-typealias MACAddressString = String(matches(Regex(#"(\#(net.hex){1,2}[\.:-]){5}(\#(net.hex){1,2})"#)))
+typealias MACAddressString =
+  String(matches(Regex(#"(\#(net.hex){1,2}[\.:-]){5}(\#(net.hex){1,2})"#)))
 
 /// A string that contains either an IPv4 or IPv6 address.
-typealias IPAddressString = IPv4AddressString|IPv6AddressString
+typealias IPAddressString = IPv4AddressString | IPv6AddressString
 
 /// A string that contains either an IPv4 or IPv6 address and port.
-typealias IPAddressPortString = IPv4AddressPortString|IPv6AddressPortString
+typealias IPAddressPortString = IPv4AddressPortString | IPv6AddressPortString
 
 /// A string that contains either an IPv4 or IPv6 CIDR range.
-typealias IPCIDRString = IPv4CIDRString|IPv6CIDRString
+typealias IPCIDRString = IPv4CIDRString | IPv6CIDRString
 
 /// An IPv4 or IPv6 address.
-typealias IPAddress = IPv4Address|IPv6Address
+typealias IPAddress = IPv4Address | IPv6Address
 
 /// An IPv4 or IPv6 network.
-typealias IPNetwork = IPv4Network|IPv6Network
+typealias IPNetwork = IPv4Network | IPv6Network
 
 /// A string that contains an IPv4 address.
 // language=RegExp
@@ -130,24 +134,30 @@ typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/[0-9]{1,3}"
 
 /// Creates an [IPAddress] from an [IPAddressString].
 function IP(ip: IPAddressString): IPAddress =
-  if (ip is IPv6AddressString) IPv6Address(ip)
-  else if (ip is IPv4AddressString) IPv4Address(ip)
-  else throw("Invalid IP: \(ip)")
+  if (ip is IPv6AddressString)
+    IPv6Address(ip)
+  else if (ip is IPv4AddressString)
+    IPv4Address(ip)
+  else
+    throw("Invalid IP: \(ip)")
 
 /// Creates an [IPv4Address] from an [IPv4AddressString].
 function IPv4Address(ip: IPv4AddressString): IPv4Address = new {
   local parts = ip.split(".")
-  repr = parts[0].toInt().shl(24)
-    .or(parts[1].toInt().shl(16))
-    .or(parts[2].toInt().shl(8))
-    .or(parts[3].toInt())
+  repr =
+    parts[0]
+      .toInt()
+      .shl(24)
+      .or(parts[1].toInt().shl(16))
+      .or(parts[2].toInt().shl(8))
+      .or(parts[3].toInt())
 }
 
 /// An IPv4 address.
 class IPv4Address {
   repr: UInt32
 
-  const hidden bitWidth: UInt = 32
+  hidden const bitWidth: UInt = 32
 
   local self = this
 
@@ -166,32 +176,36 @@ class IPv4Address {
   /// return the ip address [n] after this one
   function add(n: UInt32): IPv4Address = new { repr = self.repr + n }
 
-  function toString(): IPv4AddressString = new Listing<String> {
-    repr.ushr(24).and(math.maxUInt8).toString()
-    repr.ushr(16).and(math.maxUInt8).toString()
-    repr.ushr(8).and(math.maxUInt8).toString()
-    repr.and(math.maxUInt8).toString()
-  }.join(".")
+  function toString(): IPv4AddressString =
+    new Listing<String> {
+      repr.ushr(24).and(math.maxUInt8).toString()
+      repr.ushr(16).and(math.maxUInt8).toString()
+      repr.ushr(8).and(math.maxUInt8).toString()
+      repr.and(math.maxUInt8).toString()
+    }.join(".")
 }
 
 // noinspection TypeMismatch
 /// Creates an [IPv6Address] from an [IPv6AddressString].
 function IPv6Address(ip: IPv6AddressString): IPv6Address =
   let (idx = ip.lastIndexOfOrNull("%"))
-  let (scope = idx.ifNonNull((it) -> ip.drop(it+1).toInt()))
+  let (scope = idx.ifNonNull((it) -> ip.drop(it + 1).toInt()))
   let (ip = idx.ifNonNull((it) -> ip.take(it)) ?? ip)
   let (ipIdx = ip.indexOfOrNull(Regex(":\(ipv4String)$")))
-  let (ipv4 = ipIdx.ifNonNull((_) -> ip.drop(ipIdx+1).split(".").map((s) -> s.toInt())))
+  let (ipv4 = ipIdx.ifNonNull((_) -> ip.drop(ipIdx + 1).split(".").map((s) -> s.toInt())))
   let (ip = ipIdx.ifNonNull((it) -> ip.replaceRange(it, ip.length, ":0:0")) ?? ip)
   let (_ip = expandIPv6AddressString(ip).toLowerCase().split(":"))
     new {
-      repr = u128.UInt128(
-        parseHex32(_ip[0] + _ip[1]),
-        parseHex32(_ip[2] + _ip[3]),
-        parseHex32(_ip[4] + _ip[5]),
-        if (ipv4 != null) ipv4[0].shl(24) + ipv4[1].shl(16) + ipv4[2].shl(8) + ipv4[3]
-        else parseHex32(_ip[6] + _ip[7])
-      )
+      repr =
+        u128.UInt128(
+          parseHex32(_ip[0] + _ip[1]),
+          parseHex32(_ip[2] + _ip[3]),
+          parseHex32(_ip[4] + _ip[5]),
+          if (ipv4 != null)
+            ipv4[0].shl(24) + ipv4[1].shl(16) + ipv4[2].shl(8) + ipv4[3]
+          else
+            parseHex32(_ip[6] + _ip[7])
+        )
       scopeId = scope
     }
 
@@ -204,47 +218,53 @@ class IPv6Address {
   /// Only addresses of [non-global scope][isNonGlobalScope] are allowed to have a scope ID.
   scopeId: UInt(isNonGlobalScope)?
 
-  const hidden bitWidth: UInt = 128
+  hidden const bitWidth: UInt = 128
 
   /// Tells if this address is the unspecified address (`::`).
-  fixed hidden isUnspecified: Boolean = repr == u128.zero
+  hidden fixed isUnspecified: Boolean = repr == u128.zero
 
   /// Tells if this address is the loopback address (`::1`).
-  fixed hidden isLoopback: Boolean = repr == u128.one
+  hidden fixed isLoopback: Boolean = repr == u128.one
 
   /// Tells if this address is an IPv4-mapped address (`::ffff:0:0/96`).
-  fixed hidden isIPv4Mapped: Boolean =
-    repr.hihi == 0 && repr.hilo == 0 && repr.lohi == 0xffff
+  hidden fixed isIPv4Mapped: Boolean = repr.hihi == 0 && repr.hilo == 0 && repr.lohi == 0xffff
 
   /// Tells if this address is an IPv4-embedded address using the Well-Known Prefix (`64:ff9b::/96`) described by
   /// [RFC 6052 §2.1](https://tools.ietf.org/html/rfc6052#section-2.1).
-  fixed hidden isIPv4Embedded: Boolean =
-    repr.hihi == 0x64ff9b && repr.hilo == 0 && repr.lohi == 0
+  hidden fixed isIPv4Embedded: Boolean = repr.hihi == 0x64ff9b && repr.hilo == 0 && repr.lohi == 0
 
   /// Tells if this address has non-global unicast or multicast scope.
   ///
   /// Returns [true] for link-local unicast and for multicast with "scop" field less than global. Returns [false] for
   /// the [unspecified address][isUnspecified] and the [loopback address][isLoopback], and for site-local addresses as
   /// per [RFC 4291 §2.5.7](https://tools.ietf.org/html/rfc4291#section-2.5.7).
-  fixed hidden isNonGlobalScope: Boolean =
-    (repr.hihi == 0xfe800000 && repr.hilo == 0) ||
-      (repr.hihi.ushr(24) == 0xff && repr.hihi.ushr(16).and(0xF) < 0xE)
+  hidden fixed isNonGlobalScope: Boolean =
+    (repr.hihi == 0xfe800000 && repr.hilo == 0)
+      || (repr.hihi.ushr(24) == 0xff && repr.hihi.ushr(16).and(0xF) < 0xE)
 
   local self = this
 
   /// maskHi generates a mask of 1s in the top [prefix] bits of a [u128.UInt128].
   function maskHi(prefix: UInt(isBetween(0, bitWidth))): u128.UInt128 =
-    if (prefix <= 32) u128.UInt128(mask32Hi(prefix), 0, 0, 0)
-    else if (prefix <= 64) u128.UInt128(math.maxUInt32, mask32Hi(prefix - 32), 0, 0)
-    else if (prefix <= 96) u128.UInt128(math.maxUInt32, math.maxUInt32, mask32Hi(prefix - 64), 0)
-    else u128.UInt128(math.maxUInt32, math.maxUInt32, math.maxUInt32, mask32Hi(prefix - 96))
+    if (prefix <= 32)
+      u128.UInt128(mask32Hi(prefix), 0, 0, 0)
+    else if (prefix <= 64)
+      u128.UInt128(math.maxUInt32, mask32Hi(prefix - 32), 0, 0)
+    else if (prefix <= 96)
+      u128.UInt128(math.maxUInt32, math.maxUInt32, mask32Hi(prefix - 64), 0)
+    else
+      u128.UInt128(math.maxUInt32, math.maxUInt32, math.maxUInt32, mask32Hi(prefix - 96))
 
   /// maskLo generates a mask of 1s in the bottom [suffix] bits of a [u128.UInt128].
   function maskLo(suffix: UInt(isBetween(0, bitWidth))): u128.UInt128 =
-    if (suffix <= 32) u128.UInt128(0, 0, 0, mask32Lo(suffix))
-    else if (suffix <= 64) u128.UInt128(0, 0, mask32Lo(suffix - 32), math.maxUInt32)
-    else if (suffix <= 96) u128.UInt128(0, mask32Lo(suffix - 64), math.maxUInt32, math.maxUInt32)
-    else u128.UInt128(mask32Lo(suffix - 96), math.maxUInt32, math.maxUInt32, math.maxUInt32)
+    if (suffix <= 32)
+      u128.UInt128(0, 0, 0, mask32Lo(suffix))
+    else if (suffix <= 64)
+      u128.UInt128(0, 0, mask32Lo(suffix - 32), math.maxUInt32)
+    else if (suffix <= 96)
+      u128.UInt128(0, mask32Lo(suffix - 64), math.maxUInt32, math.maxUInt32)
+    else
+      u128.UInt128(mask32Lo(suffix - 96), math.maxUInt32, math.maxUInt32, math.maxUInt32)
 
   /// reverse returns the PTR record name for this address.
   function reverse(): String = new IPv6Network { base = self; prefix = self.bitWidth }.reverse()
@@ -259,25 +279,28 @@ class IPv6Address {
   ///
   /// This includes returning the address in the alternative IPv4-suffixed format if it is [IPv4-mapped][isIPv4Mapped]
   /// or [IPv4-embedded][isIPv4Embedded].
-  function toString(): IPv6AddressString = _compressIPv6Groups(new Listing {
-    repr.hihi.ushr(16).toRadixString(16)
-    repr.hihi.and(math.maxUInt16).toRadixString(16)
-    repr.hilo.ushr(16).toRadixString(16)
-    repr.hilo.and(math.maxUInt16).toRadixString(16)
-    repr.lohi.ushr(16).toRadixString(16)
-    repr.lohi.and(math.maxUInt16).toRadixString(16)
-    when (isIPv4Mapped || isIPv4Embedded) {
+  function toString(): IPv6AddressString =
+    _compressIPv6Groups(
       new Listing {
-        repr.lolo.ushr(24).toString()
-        repr.lolo.ushr(16).and(0xFF).toString()
-        repr.lolo.ushr(8).and(0xFF).toString()
-        repr.lolo.and(0xFF).toString()
-      }.join(".")
-    } else {
-      repr.lolo.ushr(16).toRadixString(16)
-      repr.lolo.and(math.maxUInt16).toRadixString(16)
-    }
-  }.join(":")) + (scopeId.ifNonNull((id) -> "%\(id)") ?? "")
+        repr.hihi.ushr(16).toRadixString(16)
+        repr.hihi.and(math.maxUInt16).toRadixString(16)
+        repr.hilo.ushr(16).toRadixString(16)
+        repr.hilo.and(math.maxUInt16).toRadixString(16)
+        repr.lohi.ushr(16).toRadixString(16)
+        repr.lohi.and(math.maxUInt16).toRadixString(16)
+        when (isIPv4Mapped || isIPv4Embedded) {
+          new Listing {
+            repr.lolo.ushr(24).toString()
+            repr.lolo.ushr(16).and(0xFF).toString()
+            repr.lolo.ushr(8).and(0xFF).toString()
+            repr.lolo.and(0xFF).toString()
+          }.join(".")
+        } else {
+          repr.lolo.ushr(16).toRadixString(16)
+          repr.lolo.and(math.maxUInt16).toRadixString(16)
+        }
+      }.join(":")
+    ) + (scopeId.ifNonNull((id) -> "%\(id)") ?? "")
 
   /// Returns the [IPv6Address] as a string in expanded form.
   ///
@@ -285,23 +308,29 @@ class IPv6Address {
   /// ```
   /// IPv6Address("fe80::1").toExpandedString() == "fe80:0000:0000:0000:0000:0000:0000:0001"
   /// ```
-  function toExpandedString(): IPv6AddressString = expandIPv6AddressString(new Listing {
-    repr.hihi.ushr(16).toRadixString(16)
-    repr.hihi.and(math.maxUInt16).toRadixString(16)
-    repr.hilo.ushr(16).toRadixString(16)
-    repr.hilo.and(math.maxUInt16).toRadixString(16)
-    repr.lohi.ushr(16).toRadixString(16)
-    repr.lohi.and(math.maxUInt16).toRadixString(16)
-    repr.lolo.ushr(16).toRadixString(16)
-    repr.lolo.and(math.maxUInt16).toRadixString(16)
-  }.join(":")) + (scopeId.ifNonNull((id) -> "%\(id)") ?? "")
+  function toExpandedString(): IPv6AddressString =
+    expandIPv6AddressString(
+      new Listing {
+        repr.hihi.ushr(16).toRadixString(16)
+        repr.hihi.and(math.maxUInt16).toRadixString(16)
+        repr.hilo.ushr(16).toRadixString(16)
+        repr.hilo.and(math.maxUInt16).toRadixString(16)
+        repr.lohi.ushr(16).toRadixString(16)
+        repr.lohi.and(math.maxUInt16).toRadixString(16)
+        repr.lolo.ushr(16).toRadixString(16)
+        repr.lolo.and(math.maxUInt16).toRadixString(16)
+      }.join(":")
+    ) + (scopeId.ifNonNull((id) -> "%\(id)") ?? "")
 }
 
 /// Creates an [IPNetwork] from an IPv4 or IPv6 CIDR block string
 function IPNetwork(cidr: IPCIDRString): IPNetwork =
-  if (cidr is IPv4CIDRString) IPv4Network(cidr)
-  else if (cidr is IPv6CIDRString) IPv6Network(cidr)
-  else throw("Invalid network CIDR: \(cidr)")
+  if (cidr is IPv4CIDRString)
+    IPv4Network(cidr)
+  else if (cidr is IPv6CIDRString)
+    IPv6Network(cidr)
+  else
+    throw("Invalid network CIDR: \(cidr)")
 
 /// Creates an [IPv4Network] from an IPv4 CIDR block string
 function IPv4Network(cidr: IPv4CIDRString): IPv4Network = new {
@@ -317,9 +346,9 @@ class IPv4Network {
   /// The CIDR prefix of this network
   prefix: UInt(isBetween(0, bitWidth))
 
-  fixed hidden bitWidth = base.bitWidth
+  hidden fixed bitWidth = base.bitWidth
 
-  const hidden reverseBitResolution: UInt = 8
+  hidden const reverseBitResolution: UInt = 8
 
   local self = this
 
@@ -332,22 +361,31 @@ class IPv4Network {
   fixed lastAddress: IPv4Address = new { repr = base.repr.or(base.maskLo(bitWidth - prefix)) }
 
   /// Return the subnet-mask for this network.
-  function getSubnetMask(): IPv4AddressString = new IPv4Address { repr = base.maskHi(prefix) }.toString()
+  function getSubnetMask(): IPv4AddressString =
+    new IPv4Address { repr = base.maskHi(prefix) }.toString()
 
   /// Return true if this network contains [ip].
-  function contains(ip: IPv4Address): Boolean = firstAddress.repr <= ip.repr && ip.repr <= lastAddress.repr
+  function contains(ip: IPv4Address): Boolean =
+    firstAddress.repr <= ip.repr && ip.repr <= lastAddress.repr
 
   /// Generate the name of the reverse DNS zone for this network.
-  function reverse(): String = base.toString().split(".").take(prefix ~/ reverseBitResolution).reverse().join(".") + ".in-addr.arpa"
+  function reverse(): String =
+    base.toString().split(".").take(prefix ~/ reverseBitResolution).reverse().join(".")
+      + ".in-addr.arpa"
 
   /// Calculate all subnets of this network with prefix [target].
   /// For example, given IPv4Network("10.53.120.0/21").subdivideTo(24), it outputs 8 /24 networks
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv4Network> =
-    if (prefix == target) new { self }
-    else new {
-      ...new IPv4Network { base = self.base; prefix = self.prefix + 1 }.subdivideTo(target)
-      ...new IPv4Network { base = new { repr = self.base.repr + 1.shl(bitWidth - self.prefix - 1) }; prefix = self.prefix + 1 }.subdivideTo(target)
-    }
+    if (prefix == target)
+      new { self }
+    else
+      new {
+        ...new IPv4Network { base = self.base; prefix = self.prefix + 1 }.subdivideTo(target)
+        ...new IPv4Network {
+          base = new { repr = self.base.repr + 1.shl(bitWidth - self.prefix - 1) }
+          prefix = self.prefix + 1
+        }.subdivideTo(target)
+      }
 
   function toString(): String = "\(base.toString())/\(prefix)"
 }
@@ -373,9 +411,9 @@ class IPv6Network {
   /// The CIDR prefix of this network
   prefix: UInt(isBetween(0, bitWidth))
 
-  fixed hidden bitWidth = base.bitWidth
+  hidden fixed bitWidth = base.bitWidth
 
-  const hidden reverseBitResolution: UInt = 4
+  hidden const reverseBitResolution: UInt = 4
 
   local self = this
 
@@ -391,21 +429,35 @@ class IPv6Network {
   ///
   /// If both [base.scopeId][IPv6Address.scopeId] and [ip.scopeId][IPv6Address.scopeId] are non-[null], they must match.
   /// If either is [null] then scope ID is ignored.
-  function contains(ip: IPv6Address): Boolean = firstAddress.repr.le(ip.repr) && ip.repr.le(lastAddress.repr) &&
-    (base.scopeId == ip.scopeId || base.scopeId == null || ip.scopeId == null)
+  function contains(ip: IPv6Address): Boolean =
+    firstAddress.repr.le(ip.repr)
+      && ip.repr.le(lastAddress.repr)
+      && (base.scopeId == ip.scopeId || base.scopeId == null || ip.scopeId == null)
 
   /// Generate the name of the reverse DNS zone for this network.
-  function reverse(): String = (base) { scopeId = null }.toExpandedString().replaceAll(":", "").chars.take(prefix ~/ reverseBitResolution).reverse().join(".") + ".ip6.arpa"
+  function reverse(): String =
+    (base) { scopeId = null }
+      .toExpandedString()
+      .replaceAll(":", "")
+      .chars
+      .take(prefix ~/ reverseBitResolution)
+      .reverse()
+      .join(".") + ".ip6.arpa"
 
   /// Calculate all subnets of this network with prefix [target].
   ///
   /// For example, given `IPv6Network("2620:149:a:960::/61").subdivideTo(64)`, it outputs 8 /64 networks
   function subdivideTo(target: UInt(isBetween(0, bitWidth) && this >= prefix)): Listing<IPv6Network> =
-    if (prefix == target) new { self }
-    else new {
-      ...(self) { prefix = self.prefix + 1 }.subdivideTo(target)
-      ...(self) { base { repr = self.base.repr.add(u128.one.shl(bitWidth - self.prefix - 1)) }; prefix = self.prefix + 1 }.subdivideTo(target)
-    }
+    if (prefix == target)
+      new { self }
+    else
+      new {
+        ...(self) { prefix = self.prefix + 1 }.subdivideTo(target)
+        ...(self) {
+          base { repr = self.base.repr.add(u128.one.shl(bitWidth - self.prefix - 1)) }
+          prefix = self.prefix + 1
+        }.subdivideTo(target)
+      }
 
   function toString(): String = "\(base)/\(prefix)"
 }
@@ -430,20 +482,35 @@ function IPv6Range(start: IPv6Address, end: IPv6Address): Listing<IPv6Address> =
 /// although any leading zeroes on the IPv4 components will be dropped.
 const function expandIPv6AddressString(_ip: IPv6AddressString): IPv6AddressString =
   let (idx = _ip.lastIndexOfOrNull("%"))
-    if ((idx ?? _ip.length) == 39 && !_ip.contains(".")) _ip // assume it's already canonicalized
+    if ((idx ?? _ip.length) == 39 && !_ip.contains("."))
+      _ip // assume it's already canonicalized
     else
       let (scope = idx.ifNonNull((it) -> _ip.drop(it)))
       let (ip = idx.ifNonNull((it) -> _ip.take(it)) ?? _ip)
       let (ipIdx = ip.indexOfOrNull(Regex(":\(ipv4String)$")))
       let (ipv4 = ipIdx.ifNonNull((it) -> ip.drop(it).replaceAll(Regex("0+(?=[0-9])"), "")))
-      let (ip = ipIdx.ifNonNull((it) -> if (ip[it-1] == ":") ip.take(it+1) else ip.take(it)) ?? ip)
+      let (
+        ip = ipIdx.ifNonNull((it) -> if (ip[it - 1] == ":") ip.take(it + 1) else ip.take(it)) ?? ip
+      )
       let (ip = if (ip.endsWith("::")) ip + "0" else ip)
       let (groupCount = if (ipv4 == null) 8 else 6)
-      let (stuff = ip.split("::").map((half) -> half.split(":").map((octet) -> octet.padStart(4, "0"))))
-        (if (stuff.length == 1) stuff.first.join(":")
-        else if (stuff.length == 2) (stuff.first + List("0000").repeat(groupCount - stuff.first.length - stuff.last.length) + stuff.last).join(":")
-        else throw("unintelligible IPv6 address: " + _ip))
-        + (ipv4 ?? "") + (scope ?? "")
+      let (
+        stuff = ip.split("::").map((half) -> half.split(":").map((octet) -> octet.padStart(4, "0")))
+      )
+        (
+          if (stuff.length == 1)
+            stuff.first.join(":")
+          else if (stuff.length == 2)
+            (
+              stuff.first
+                + List("0000").repeat(groupCount - stuff.first.length - stuff.last.length)
+                + stuff.last
+            ).join(":")
+          else
+            throw("unintelligible IPv6 address: " + _ip)
+        )
+          + (ipv4 ?? "")
+          + (scope ?? "")
 
 // noinspection TypeMismatch
 /// Compresses IPv6 addresses by stripping leading zeros from each component and collapsing repeated zero components to `::`.
@@ -458,21 +525,37 @@ const function compressIPv6AddressString(ip: IPv6AddressString): IPv6AddressStri
   let (idx = ip.lastIndexOfOrNull("%"))
   let (scope = idx.ifNonNull((it) -> ip.drop(it).replaceFirst(Regex("^%0+(?=[0-9])"), "%")))
   let (ip = idx.ifNonNull((it) -> ip.take(it)) ?? ip)
-  let (trimmed = ip.split(":").map((octet) ->
-    if (octet == "0000") "0"
-    else if (octet.contains(".")) octet // must be a trailing IPv4 address
-    else octet.dropWhile((c) -> c == "0")
-  ).join(":"))
-  _compressIPv6Groups(trimmed) + (scope ?? "")
+  let (
+    trimmed =
+      ip
+        .split(":")
+        .map((octet) ->
+          if (octet == "0000")
+            "0"
+          else if (octet.contains("."))
+            octet // must be a trailing IPv4 address
+          else
+            octet.dropWhile((c) -> c == "0")
+        )
+        .join(":")
+  )
+    _compressIPv6Groups(trimmed) + (scope ?? "")
 
 // Performs only the portion of IPv6 address canonicalization that is replacing the longest sequence of zeroes
 // with `::`.
 local const function _compressIPv6Groups(ip: String): IPv6AddressString =
-  let (match = Regex(#"(?<=:|^)(?:0:)+0(?=:|$)"#).findMatchesIn(ip).maxByOrNull((it) -> it.value.length))
-    if (match == null) ip // no groups to replace with ::
-    else if (match.start == 0 && match.end == ip.length) "::"
-    else if (match.start == 0 || match.end == ip.length) ip.replaceRange(match.start, match.end, ":")
-    else ip.replaceRange(match.start, match.end, "")
+  let (
+    match =
+      Regex(#"(?<=:|^)(?:0:)+0(?=:|$)"#).findMatchesIn(ip).maxByOrNull((it) -> it.value.length)
+  )
+    if (match == null)
+      ip // no groups to replace with ::
+    else if (match.start == 0 && match.end == ip.length)
+      "::"
+    else if (match.start == 0 || match.end == ip.length)
+      ip.replaceRange(match.start, match.end, ":")
+    else
+      ip.replaceRange(match.start, match.end, "")
 
 function MACAddress(mac: MACAddressString): MACAddress = new {
   repr = mac.split(Regex("[.:-]")).map((octet) -> parseHexOctet(octet))
@@ -483,23 +566,25 @@ class MACAddress {
 
   local self = this
 
-  function toString(): MACAddressString = repr.map((octet) -> octet.toRadixString(16).padStart(2, "0")).join(":")
+  function toString(): MACAddressString =
+    repr.map((octet) -> octet.toRadixString(16).padStart(2, "0")).join(":")
 
   function eui64(addr: IPv6Address): IPv6Address = new {
-    repr = u128.UInt128(
-      addr.repr.hihi,
-      addr.repr.hilo,
-      uint32FromBytes(self.repr[0].xor(0x02), self.repr[1], self.repr[2], 0xff),
-      uint32FromBytes(0xfe, self.repr[3], self.repr[4], self.repr[5])
-    )
+    repr =
+      u128.UInt128(
+        addr.repr.hihi,
+        addr.repr.hilo,
+        uint32FromBytes(self.repr[0].xor(0x02), self.repr[1], self.repr[2], 0xff),
+        uint32FromBytes(0xfe, self.repr[3], self.repr[4], self.repr[5])
+      )
   }
 }
 
 /// parseHex tranforms a single hexadecimal character into its unsigned integer representation.
 function parseHex(digit: Char): UInt8 =
   let (d = digit.toLowerCase())
-    "0123456789abcdef".chars.findIndexOrNull((it) -> it == d) ??
-      throw("Unrecognized hex digit: \(d)")
+    "0123456789abcdef".chars.findIndexOrNull((it) -> it == d)
+      ?? throw("Unrecognized hex digit: \(d)")
 
 /// parseHexOctet tranforms a two hexadecimal characters into its unsigned integer representation.
 function parseHexOctet(octet: String(length == 2)): UInt8 = byteLut[octet.toLowerCase()]
@@ -512,12 +597,16 @@ function parseHex32(s: String(length == 8)): UInt32 =
     .fold(0, (acc, it) -> acc.shl(8) + parseHexOctet(it))
 
 /// byteLut is a lookup table mapping a string of two lowercase hex digits (zero-padded) to the UInt8 value.
-const local byteLut = IntSeq(0, 255).map((it) -> it).toMap((it) -> it.toRadixString(16).padStart(2, "0"), (it) -> it)
+local const byteLut =
+  IntSeq(0, 255)
+    .map((it) -> it)
+    .toMap((it) -> it.toRadixString(16).padStart(2, "0"), (it) -> it)
 
 /// mask32Hi generates a mask of 1s in the top [prefix] bits of a [UInt32].
-const function mask32Hi(prefix: UInt(isBetween(0, 32))): UInt32 = math.maxUInt32.ushr(32-prefix).shl(32-prefix)
+const function mask32Hi(prefix: UInt(isBetween(0, 32))): UInt32 =
+  math.maxUInt32.ushr(32 - prefix).shl(32 - prefix)
 /// mask32Lo generates a mask of 1s in the bottom [suffix] bits of a [UInt32].
-const function mask32Lo(suffix: UInt(isBetween(0, 32))): UInt32 = math.maxUInt32.ushr(32-suffix)
+const function mask32Lo(suffix: UInt(isBetween(0, 32))): UInt32 = math.maxUInt32.ushr(32 - suffix)
 
 /// uint32FromBytes constructs a [UInt32] from four [UInt8] values.
 const function uint32FromBytes(hihi: UInt8, hilo: UInt8, lohi: UInt8, lolo: UInt8): UInt32 =

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -140,14 +140,14 @@ typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/[0-9]{1,3}"
 ///
 /// For example, `"10.0.0.0/24"` qualifies, but `"10.0.0.1/24"` does not, since the latter has host bits set.
 typealias IPv4NetworkString =
-  String(this is IPv4CIDRString && let (n = net.IPv4Network(this)) n.base == n.firstAddress)
+  String(this is IPv4CIDRString, let (n = net.IPv4Network(this)) n.base == n.firstAddress)
 
 /// A string that contains a strict IPv6 network, i.e. an IPv6 CIDR block whose address has no bits
 /// set beyond its prefix.
 ///
 /// For example, `"2001:db8::/32"` qualifies, but `"2001:db8::1/32"` does not, since the latter has host bits set.
 typealias IPv6NetworkString =
-  String(this is IPv6CIDRString && let (n = net.IPv6Network(this)) n.base == n.firstAddress)
+  String(this is IPv6CIDRString, let (n = net.IPv6Network(this)) n.base == n.firstAddress)
 
 /// Creates an [IPAddress] from an [IPAddressString].
 function IP(ip: IPAddressString): IPAddress =
@@ -385,11 +385,13 @@ class IPv4Network {
   function contains(ip: IPv4Address): Boolean =
     firstAddress.repr <= ip.repr && ip.repr <= lastAddress.repr
 
-  /// Return true if [other] is a subnet of this network, i.e. every address in [other] is also in this network.
+  /// Return true if [other] is a subnet of this network, i.e. other's prefix starts with this
+  /// network's prefix.
   function containsNetwork(other: IPv4Network): Boolean =
-    self.contains(other.firstAddress) && self.contains(other.lastAddress)
+    prefix <= other.prefix && firstAddress.repr == other.base.repr.and(other.base.maskHi(prefix))
 
-  /// Return true if this network and [other] share at least one address.
+  /// Return true if this network overlaps with the other, i.e. either [other] is a subnet of this
+  /// network or vice versa.
   function overlaps(other: IPv4Network): Boolean =
     self.containsNetwork(other) || other.containsNetwork(self)
 
@@ -421,10 +423,7 @@ class IPv4Network {
   ///
   /// For example, given `IPv4Network("10.53.120.0/21").subnet(24, 3)`, it outputs
   /// `IPv4Network("10.53.123.0/24")`.
-  function subnet(
-    target: UInt(isBetween(0, bitWidth) && this >= prefix),
-    n: UInt32
-  ): net.IPv4Network =
+  function subnet(target: UInt(isBetween(0, bitWidth), this >= prefix), n: UInt32): net.IPv4Network =
     if (1.shl(target - prefix) <= n)
       throw(
         "subnet number \(n) exceeds maximum possible between prefix /\(prefix) and target /\(target)"
@@ -482,14 +481,18 @@ class IPv6Network {
       && ip.repr.le(lastAddress.repr)
       && (base.scopeId == ip.scopeId || base.scopeId == null || ip.scopeId == null)
 
-  /// Return true if [other] is a subnet of this network, i.e. every address in [other] is also in this network.
+  /// Return true if [other] is a subnet of this network, i.e. other's prefix starts with this
+  /// network's prefix.
   ///
   /// If both [base.scopeId][IPv6Address.scopeId] and [other.base.scopeId][IPv6Address.scopeId] are non-[null],
   /// they must match. If either is [null] then scope ID is ignored.
   function containsNetwork(other: IPv6Network): Boolean =
-    self.contains(other.firstAddress) && self.contains(other.lastAddress)
+    prefix <= other.prefix
+      && firstAddress.repr == other.base.repr.and(other.base.maskHi(prefix))
+      && (base.scopeId == other.base.scopeId || base.scopeId == null || other.base.scopeId == null)
 
-  /// Return true if this network and [other] share at least one address.
+  /// Return true if this network overlaps with the other, i.e. either [other] is a subnet of this
+  /// network or vice versa.
   ///
   /// If both [base.scopeId][IPv6Address.scopeId] and [other.base.scopeId][IPv6Address.scopeId] are non-[null],
   /// they must match. If either is [null] then scope ID is ignored.
@@ -529,10 +532,7 @@ class IPv6Network {
   ///
   /// For example, given `IPv6Network("2620:149:a:960::/64").subnet(80, 10)`, it outputs
   /// `IPv6Network("2620:149:a:960:a::/80")`.
-  function subnet(
-    target: UInt(isBetween(0, bitWidth) && this >= prefix),
-    n: UInt32
-  ): net.IPv6Network =
+  function subnet(target: UInt(isBetween(0, bitWidth), this >= prefix), n: UInt32): net.IPv6Network =
     // `target - prefix == bitWidth` (only possible when prefix == 0 and target == bitWidth) is skipped:
     // the true subnet count, 2^bitWidth, isn't representable as a UInt128, and shl() wraps around to 0
     // in that case. The check is safe to skip here since n is a UInt32, always < 2^bitWidth.

--- a/packages/pkl.experimental.net/net.pkl
+++ b/packages/pkl.experimental.net/net.pkl
@@ -98,6 +98,9 @@ typealias IPAddressPortString = IPv4AddressPortString | IPv6AddressPortString
 /// A string that contains either an IPv4 or IPv6 CIDR range.
 typealias IPCIDRString = IPv4CIDRString | IPv6CIDRString
 
+/// A string that contains either a IPv4 of IPv6 network.
+typealias IPNetworkString = IPv4NetworkString | IPv6NetworkString
+
 /// An IPv4 or IPv6 address.
 typealias IPAddress = IPv4Address | IPv6Address
 
@@ -131,6 +134,20 @@ typealias IPv4CIDRString = String(matches(Regex(#"\#(net.ipv4String)/[0-9]{1,2}"
 /// A string that contains an IPv6 address.
 // language=RegExp
 typealias IPv6CIDRString = String(matches(Regex(#"\#(net.ipv6String)/[0-9]{1,3}"#)))
+
+/// A string that contains a strict IPv4 network, i.e. an IPv4 CIDR block whose address has no bits
+/// set beyond its prefix.
+///
+/// For example, `"10.0.0.0/24"` qualifies, but `"10.0.0.1/24"` does not, since the latter has host bits set.
+typealias IPv4NetworkString =
+  String(this is IPv4CIDRString && let (n = net.IPv4Network(this)) n.base == n.firstAddress)
+
+/// A string that contains a strict IPv6 network, i.e. an IPv6 CIDR block whose address has no bits
+/// set beyond its prefix.
+///
+/// For example, `"2001:db8::/32"` qualifies, but `"2001:db8::1/32"` does not, since the latter has host bits set.
+typealias IPv6NetworkString =
+  String(this is IPv6CIDRString && let (n = net.IPv6Network(this)) n.base == n.firstAddress)
 
 /// Creates an [IPAddress] from an [IPAddressString].
 function IP(ip: IPAddressString): IPAddress =

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ local baseIP = net.IPv6Address("::")
 
 facts {
   ["MACAddress"] {
-    net.MACAddress("34:73:5A:FA:AF:22").eui64(baseIP).toExpandedString() == "0000:0000:0000:0000:3673:5aff:fefa:af22"
+    net.MACAddress("34:73:5A:FA:AF:22").eui64(baseIP).toExpandedString()
+      == "0000:0000:0000:0000:3673:5aff:fefa:af22"
   }
   // note: IPv4Address() and IPv6Address() must be invoked prior to any tests that reference the IPv[46]AddressString
   // typealiases. This works around a pkl 0.25 bug that otherwise causes java exceptions.
@@ -314,7 +315,8 @@ facts {
   }
   ["IPv6Address()"] {
     net.IPv6Address("fe80::1").repr == u128.UInt128(0xFE800000, 0, 0, 1)
-    net.IPv6Address("1:10:100:1000:ff00:0ff0:00ff:f00f").repr == u128.UInt128(0x10010, 0x1001000, 0xff000ff0, 0xfff00f)
+    net.IPv6Address("1:10:100:1000:ff00:0ff0:00ff:f00f").repr
+      == u128.UInt128(0x10010, 0x1001000, 0xff000ff0, 0xfff00f)
     net.IPv6Address("::a:b").repr == u128.UInt128(0, 0, 0, 0xa000b)
     net.IPv6Address("2001::").repr == u128.UInt128(0x20010000, 0, 0, 0)
     net.IPv6Address("::ffff:129.144.52.38").repr == u128.UInt128(0, 0, 0xffff, 0x81903426)
@@ -329,14 +331,16 @@ facts {
     net.IPv6Address("fe80::%123").scopeId == 123
     net.IPv6Address("fe80::%0").scopeId == 0
     // check that manually-constructed addresses respect restrictions on scopeId
-    let (ip = net.IPv6Address("::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("::1")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("fec0::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("2001:db8::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("ff0e::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("ff0f::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("fe7f::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
-    let (ip = net.IPv6Address("fe80:0:0:1::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId ) != null
+    let (ip = net.IPv6Address("::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("::1")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("fec0::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("2001:db8::"))
+      module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("ff0e::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("ff0f::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("fe7f::")) module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
+    let (ip = net.IPv6Address("fe80:0:0:1::"))
+      module.catch(() -> (ip) { scopeId = 1 }.scopeId) != null
   }
   ["IPv6Address methods work with scopeId"] {
     net.IPv6Address("fe80::%1").next() == net.IPv6Address("fe80::1%1")
@@ -410,12 +414,70 @@ facts {
     net.IPv6Network("fe80::/64").firstAddress.scopeId == null
     net.IPv6Network("fe80::/64").lastAddress.scopeId == null
   }
+  ["IPv4Network.subnet()"] {
+    net.IPv4Network("10.53.120.0/21").subnet(24, 3) == net.IPv4Network("10.53.123.0/24")
+    net.IPv4Network("10.53.120.0/21").subnet(24, 0) == net.IPv4Network("10.53.120.0/24")
+    net.IPv4Network("10.53.120.0/21").subnet(24, 7) == net.IPv4Network("10.53.127.0/24") // last valid subnet
+    net.IPv4Network("10.53.120.0/21").subnet(21, 0) == net.IPv4Network("10.53.120.0/21") // target == prefix
+    module.catch(() -> net.IPv4Network("10.53.120.0/21").subnet(24, 8)) != null // one past the last valid subnet
+  }
+  ["IPv4Network.subnet() at the top of the address space (/32)"] {
+    // subdividing all the way down to individual hosts, right at the last IP in the address space
+    net.IPv4Network("255.255.255.252/30").subnet(32, 3) == net.IPv4Network("255.255.255.255/32")
+    // self is already a single-host (/32) network
+    net.IPv4Network("10.0.0.1/32").subnet(32, 0) == net.IPv4Network("10.0.0.1/32")
+    module.catch(() -> net.IPv4Network("10.0.0.1/32").subnet(32, 1)) != null
+    // target - prefix == bitWidth: subdividing the entire address space (/0) down to /32 hosts
+    net.IPv4Network("0.0.0.0/0").subnet(32, 0) == net.IPv4Network("0.0.0.0/32")
+    net.IPv4Network("0.0.0.0/0").subnet(32, 4294967295) == net.IPv4Network("255.255.255.255/32")
+  }
+  ["IPv6Network.subnet()"] {
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 10)
+      == net.IPv6Network("2620:149:a:960:a::/80")
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 0) == net.IPv6Network("2620:149:a:960::/80")
+    net.IPv6Network("2620:149:a:960::/64").subnet(80, 65535)
+      == net.IPv6Network("2620:149:a:960:ffff::/80") // last valid subnet
+    net.IPv6Network("2620:149:a:960::/64").subnet(64, 0) == net.IPv6Network("2620:149:a:960::/64") // target == prefix
+    module.catch(() -> net.IPv6Network("2620:149:a:960::/64").subnet(80, 65536)) != null // one past the last valid subnet
+  }
+  ["IPv6Network.subnet() at the top of the address space (/128)"] {
+    // subdividing all the way down to individual hosts, right at the last IP in the address space
+    net.IPv6Network("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/126").subnet(128, 3)
+      == net.IPv6Network("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128")
+    // self is already a single-host (/128) network
+    net.IPv6Network("::1/128").subnet(128, 0) == net.IPv6Network("::1/128")
+    module.catch(() -> net.IPv6Network("::1/128").subnet(128, 1)) != null
+    // target - prefix == bitWidth: subdividing the entire address space (/0) down to /128 hosts.
+    // 2^128 isn't representable as a UInt128, so this exercises the fallback path that skips the
+    // (otherwise-overflowing) bounds check.
+    net.IPv6Network("::/0").subnet(128, 0) == net.IPv6Network("::/128")
+    net.IPv6Network("::/0").subnet(128, 4294967295) == net.IPv6Network("::ffff:ffff/128")
+  }
+  ["IPv6Network.subnet() preserves scopeId"] {
+    net.IPv6Network("fe80::%1/64").subnet(80, 10).base.scopeId == 1
+    net.IPv6Network("fe80::/64").subnet(80, 10).base.scopeId == null
+  }
   ["IPv6Range() preserves scopeId as appropriate"] {
-    net.IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%1")).toList().every((ip) -> ip.scopeId == 1)
-    net.IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%2")).toList().every((ip) -> ip.scopeId == null)
-    net.IPv6Range(net.IPv6Address("fe80::"), net.IPv6Address("fe80::10%1")).toList().every((ip) -> ip.scopeId == null)
-    net.IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10")).toList().every((ip) -> ip.scopeId == null)
-    net.IPv6Range(net.IPv6Address("fe80::"), net.IPv6Address("fe80::10")).toList().every((ip) -> ip.scopeId == null)
+    net
+      .IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%1"))
+      .toList()
+      .every((ip) -> ip.scopeId == 1)
+    net
+      .IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10%2"))
+      .toList()
+      .every((ip) -> ip.scopeId == null)
+    net
+      .IPv6Range(net.IPv6Address("fe80::"), net.IPv6Address("fe80::10%1"))
+      .toList()
+      .every((ip) -> ip.scopeId == null)
+    net
+      .IPv6Range(net.IPv6Address("fe80::%1"), net.IPv6Address("fe80::10"))
+      .toList()
+      .every((ip) -> ip.scopeId == null)
+    net
+      .IPv6Range(net.IPv6Address("fe80::"), net.IPv6Address("fe80::10"))
+      .toList()
+      .every((ip) -> ip.scopeId == null)
   }
   ["IPv4AddressString can't contain unicode digits"] {
     // U+FF11 is FULLWIDTH DIGIT ONE

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -282,6 +282,33 @@ facts {
     !("" is net.IPv6CIDRString)
     !("0.0.0.0/10" is net.IPv6CIDRString)
   }
+  ["IPv4NetworkString"] {
+    "10.0.0.0/24" is net.IPv4NetworkString
+    "0.0.0.0/0" is net.IPv4NetworkString // whole address space: no host bits to be non-zero
+    "255.255.255.255/32" is net.IPv4NetworkString // single host: every bit is a network bit
+    !("10.0.0.1/24" is net.IPv4NetworkString) // host bits set
+    !("not a cidr" is net.IPv4NetworkString)
+    !("" is net.IPv4NetworkString)
+  }
+  ["IPv6NetworkString"] {
+    "2001:db8::/32" is net.IPv6NetworkString
+    "::/0" is net.IPv6NetworkString // whole address space: no host bits to be non-zero
+    "::1/128" is net.IPv6NetworkString // single host: every bit is a network bit
+    "fe80::%1/64" is net.IPv6NetworkString // scoped, but still canonical
+    !("2001:db8::1/32" is net.IPv6NetworkString) // host bits set
+    !("fe80::1/64" is net.IPv6NetworkString) // host bits set
+    !("fe80::1%1/64" is net.IPv6NetworkString) // scoped, host bits set
+    !("not a cidr" is net.IPv6NetworkString)
+    !("" is net.IPv6NetworkString)
+  }
+  ["IPNetworkString"] {
+    "10.0.0.0/24" is net.IPNetworkString
+    "2001:db8::/32" is net.IPNetworkString
+    !("10.0.0.1/24" is net.IPNetworkString) // host bits set
+    !("2001:db8::1/32" is net.IPNetworkString) // host bits set
+    !("not a cidr" is net.IPNetworkString)
+    !("" is net.IPNetworkString)
+  }
   ["IPv4AddressPortString"] {
     "0.0.0.0:0" is net.IPv4AddressPortString
     "255.255.255.255:65535" is net.IPv4AddressPortString

--- a/packages/pkl.experimental.net/tests/net.pkl
+++ b/packages/pkl.experimental.net/tests/net.pkl
@@ -404,6 +404,41 @@ facts {
     net.IPv6Network("fe80::/96").contains(net.IPv6Address("fe80::1%1"))
     !net.IPv6Network("fe80::%1/96").contains(net.IPv6Address("fe80::1%2"))
   }
+  ["IPv6Network.containsNetwork()"] {
+    net.IPv6Network("2001:db8::/32").containsNetwork(net.IPv6Network("2001:db8:0:1::/64")) // narrower prefix inside wider
+    !net.IPv6Network("2001:db8:0:1::/64").containsNetwork(net.IPv6Network("2001:db8::/32")) // wider isn't a subnet of narrower
+    net.IPv6Network("2001:db8::/32").containsNetwork(net.IPv6Network("2001:db8::/32")) // identical
+    !net.IPv6Network("2001:db8::/32").containsNetwork(net.IPv6Network("2001:db9::/32")) // disjoint
+    !net.IPv6Network("2001:db8::/32").containsNetwork(net.IPv6Network("::/0")) // other is wider than self, not narrower
+    // ::/0 is the entire address space: it contains every other network, including itself
+    net.IPv6Network("::/0").containsNetwork(net.IPv6Network("2001:db8::/32"))
+    net.IPv6Network("::/0").containsNetwork(net.IPv6Network("::1/128"))
+    net.IPv6Network("::/0").containsNetwork(net.IPv6Network("::/0"))
+    // ::1/128 is a single host: it only contains itself
+    net.IPv6Network("::1/128").containsNetwork(net.IPv6Network("::1/128"))
+    !net.IPv6Network("::1/128").containsNetwork(net.IPv6Network("2001:db8::/32"))
+    !net.IPv6Network("::1/128").containsNetwork(net.IPv6Network("::2/128"))
+  }
+  ["IPv6Network.containsNetwork() and scopeId"] {
+    net.IPv6Network("fe80::%1/64").containsNetwork(net.IPv6Network("fe80::%1/96")) // same scope
+    net.IPv6Network("fe80::/64").containsNetwork(net.IPv6Network("fe80::%1/96")) // self unscoped: ignored
+    net.IPv6Network("fe80::%1/64").containsNetwork(net.IPv6Network("fe80::/96")) // other unscoped: ignored
+    !net.IPv6Network("fe80::%1/64").containsNetwork(net.IPv6Network("fe80::%2/96")) // different scope
+  }
+  ["IPv6Network.overlaps()"] {
+    net.IPv6Network("2001:db8::/32").overlaps(net.IPv6Network("2001:db8::/32")) // identical
+    net.IPv6Network("2001:db8::/32").overlaps(net.IPv6Network("2001:db8:0:1::/64")) // other nested inside self
+    net.IPv6Network("2001:db8:0:1::/64").overlaps(net.IPv6Network("2001:db8::/32")) // self nested inside other
+    net.IPv6Network("::/0").overlaps(net.IPv6Network("2001:db8::/32")) // /0 overlaps everything
+    !net.IPv6Network("2001:db8::/32").overlaps(net.IPv6Network("2001:db9::/32")) // disjoint
+    !net.IPv6Network("2001:db8::/33").overlaps(net.IPv6Network("2001:db8:8000::/33")) // adjacent halves of a /32
+  }
+  ["IPv6Network.overlaps() and scopeId"] {
+    net.IPv6Network("fe80::%1/64").overlaps(net.IPv6Network("fe80::%1/96")) // same scope
+    net.IPv6Network("fe80::/64").overlaps(net.IPv6Network("fe80::%1/96")) // self unscoped: ignored
+    net.IPv6Network("fe80::%1/64").overlaps(net.IPv6Network("fe80::/96")) // other unscoped: ignored
+    !net.IPv6Network("fe80::%1/64").overlaps(net.IPv6Network("fe80::%2/96")) // different scope
+  }
   ["IPv6Network.subdivideTo() preserves scopeId"] {
     net.IPv6Network("fe80::%1/64").subdivideTo(67).toList().every((it) -> it.base.scopeId == 1)
     net.IPv6Network("fe80::/64").subdivideTo(67).toList().every((it) -> it.base.scopeId == null)
@@ -413,6 +448,21 @@ facts {
     net.IPv6Network("fe80::%1/64").lastAddress.scopeId == 1
     net.IPv6Network("fe80::/64").firstAddress.scopeId == null
     net.IPv6Network("fe80::/64").lastAddress.scopeId == null
+  }
+  ["IPv4Network.containsNetwork()"] {
+    net.IPv4Network("10.0.0.0/16").containsNetwork(net.IPv4Network("10.0.5.0/24")) // narrower prefix inside wider
+    !net.IPv4Network("10.0.5.0/24").containsNetwork(net.IPv4Network("10.0.0.0/16")) // wider isn't a subnet of narrower
+    net.IPv4Network("10.0.0.0/24").containsNetwork(net.IPv4Network("10.0.0.0/24")) // identical
+    !net.IPv4Network("10.0.0.0/24").containsNetwork(net.IPv4Network("192.168.0.0/24")) // disjoint
+    !net.IPv4Network("10.0.5.0/24").containsNetwork(net.IPv4Network("0.0.0.0/0")) // other is wider than self, not narrower
+  }
+  ["IPv4Network.overlaps()"] {
+    net.IPv4Network("10.0.0.0/24").overlaps(net.IPv4Network("10.0.0.0/24")) // identical
+    net.IPv4Network("10.0.0.0/16").overlaps(net.IPv4Network("10.0.5.0/24")) // other nested inside self
+    net.IPv4Network("10.0.5.0/24").overlaps(net.IPv4Network("10.0.0.0/16")) // self nested inside other
+    net.IPv4Network("0.0.0.0/0").overlaps(net.IPv4Network("10.0.5.0/24")) // /0 overlaps everything
+    !net.IPv4Network("10.0.0.0/24").overlaps(net.IPv4Network("192.168.0.0/24")) // disjoint
+    !net.IPv4Network("10.0.0.0/25").overlaps(net.IPv4Network("10.0.0.128/25")) // adjacent halves of a /24
   }
   ["IPv4Network.subnet()"] {
     net.IPv4Network("10.53.120.0/21").subnet(24, 3) == net.IPv4Network("10.53.123.0/24")


### PR DESCRIPTION
This pull request combines changes from #222, #223 and #224 (in individual commits, reviewable independently).

The changes proposed are:

- add a `subnet()` method to IPv4Network and IPv6Network, which can compute a subnet directly, without enumerating all
- add `containsNetwork()` and `overlaps()` methods to check subnet relationships between networks
- add a "strict" version of the IPCIDRStrings, which require host bits to be zero
- bump the version from 1.2.1 to 1.3.0, since new features are added