### PR TITLE
[pkl.experimental.syntax] Add support for object body parameters

### DIFF
--- a/packages/com.github.actions.contrib/PklProject
+++ b/packages/com.github.actions.contrib/PklProject
@@ -24,5 +24,5 @@ dependencies {
 }
 
 package {
-  version = "1.0.16"
+  version = "1.0.17"
 }

--- a/packages/com.github.actions.contrib/PklProject.deps.json
+++ b/packages/com.github.actions.contrib/PklProject.deps.json
@@ -8,7 +8,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.2.0",
       "path": "../pkl.experimental.syntax"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {

--- a/packages/k8s.contrib.crd/PklProject
+++ b/packages/k8s.contrib.crd/PklProject
@@ -29,5 +29,5 @@ dependencies {
 }
 
 package {
-  version = "4.2.2"
+  version = "4.2.3"
 }

--- a/packages/k8s.contrib.crd/PklProject.deps.json
+++ b/packages/k8s.contrib.crd/PklProject.deps.json
@@ -15,12 +15,12 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.2.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/org.json_schema.contrib@1.2.1",
       "path": "../org.json_schema.contrib"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.2.0",
       "path": "../pkl.experimental.syntax"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {

--- a/packages/moduleNameTest.pkl
+++ b/packages/moduleNameTest.pkl
@@ -32,10 +32,12 @@ local maybeQuoteIdentifier = (part: String) ->
   if (part.matches(Regex(#"[a-zA-Z$_][a-zA-Z0-9$_]*"#))) part else "`\(part)`"
 
 local function expectedModuleName(packageName: String, modulePath: String) =
+  let (packageNameParts = packageName.split("."))
+  let (packageNamePath = packageNameParts.map(maybeQuoteIdentifier).join("."))
   let (pathWithinModule = modulePath.replaceFirst("\(packageName)/", "").replaceLast(".pkl", ""))
   let (parts = pathWithinModule.split("/"))
   let (packagePath = parts.map(maybeQuoteIdentifier).join("."))
-    "\(packageName).\(packagePath)"
+    "\(packageNamePath).\(packagePath)"
 
 facts {
   for (packageName, myPklModules in allPklModules.keys.groupBy((it) -> it.split("/").first)) {

--- a/packages/org.json_schema.contrib/PklProject
+++ b/packages/org.json_schema.contrib/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,5 +25,5 @@ dependencies {
 }
 
 package {
-  version = "1.2.0"
+  version = "1.2.1"
 }

--- a/packages/org.json_schema.contrib/PklProject.deps.json
+++ b/packages/org.json_schema.contrib/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.syntax@1.2.0",
       "path": "../pkl.experimental.syntax"
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.uri@1": {

--- a/packages/pkl.experimental.syntax/ObjectBodyNode.pkl
+++ b/packages/pkl.experimental.syntax/ObjectBodyNode.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,19 +35,23 @@ module pkl.experimental.syntax.ObjectBodyNode
 
 extends "Node.pkl"
 
+import "DocCommentNode.pkl"
+import "ExpressionNode.pkl"
 import "IdentifierNode.pkl"
 import "Node.pkl"
 import "ObjectBodyNode.pkl"
-import "ExpressionNode.pkl"
-import "DocCommentNode.pkl"
 import "ParameterNode.pkl"
 
 members: Listing<MemberNode>
 
+/// Object body parameters.
+parameters: Listing<ParameterNode>
+
 /// Renders all members inline instead of on newlines
 renderInline: Boolean = false
 
-typealias MemberNode = PropertyMemberNode|ElementMemberNode|EntryMemberNode|ForGeneratorNode|WhenGeneratorNode
+typealias MemberNode =
+  PropertyMemberNode | ElementMemberNode | EntryMemberNode | ForGeneratorNode | WhenGeneratorNode
 
 class PropertyMemberNode extends Node {
   docComment: DocCommentNode?
@@ -61,20 +65,23 @@ class PropertyMemberNode extends Node {
   // The right hand side of a property cannot be both an assignment and an object body (e.g. `foo = { ... }` is illegal)
   assignment: ExpressionNode(body == null)?
 
-  local function renderRhs(currentIndent: String) = if (body != null) body.render(currentIndent) else "= " + assignment.render(currentIndent)
+  local function renderRhs(currentIndent: String) =
+    if (body != null) body.render(currentIndent) else "= " + assignment.render(currentIndent)
 
-  local function renderPropertyLine(currentIndent: String) = new Listing {
-    ...?modifiers
-    propertyName.render(currentIndent)
-    renderRhs(currentIndent)
-  }.join(" ")
+  local function renderPropertyLine(currentIndent: String) =
+    new Listing {
+      ...?modifiers
+      propertyName.render(currentIndent)
+      renderRhs(currentIndent)
+    }.join(" ")
 
-  function render(currentIndent: String) = List(
-    docComment?.render(currentIndent),
-    renderPropertyLine(currentIndent)
-  )
-    .filterNonNull()
-    .join("\n")
+  function render(currentIndent: String) =
+    List(
+      docComment?.render(currentIndent),
+      renderPropertyLine(currentIndent)
+    )
+      .filterNonNull()
+      .join("\n")
 }
 
 class ElementMemberNode extends Node {
@@ -91,9 +98,11 @@ class EntryMemberNode extends Node {
   // The right hand side of an entry cannot be both an assignment and an object body (e.g. `foo = { ... }` is illegal)
   propertyValue: ExpressionNode(body == null)?
 
-  local function renderRhs(currentIndent: String) = if (body != null) body.render(currentIndent) else "= " + propertyValue.render(currentIndent)
+  local function renderRhs(currentIndent: String) =
+    if (body != null) body.render(currentIndent) else "= " + propertyValue.render(currentIndent)
 
-  function render(currentIndent: String) = "[\(keyValue.render(currentIndent))] \(renderRhs(currentIndent))"
+  function render(currentIndent: String) =
+    "[\(keyValue.render(currentIndent))] \(renderRhs(currentIndent))"
 }
 
 class ForGeneratorNode extends Node {
@@ -105,14 +114,18 @@ class ForGeneratorNode extends Node {
 
   body: ObjectBodyNode?
 
-  function doRenderLoopControl(currentIndent: String): String = List(
-    keyParameter?.render(currentIndent)?.ifNonNull((it) -> it + ","),
-    valueParameter.render(currentIndent),
-    "in",
-    collection.render(currentIndent)
-  ).filterNonNull().join(" ")
+  function doRenderLoopControl(currentIndent: String): String =
+    List(
+      keyParameter?.render(currentIndent)?.ifNonNull((it) -> it + ","),
+      valueParameter.render(currentIndent),
+      "in",
+      collection.render(currentIndent)
+    )
+      .filterNonNull()
+      .join(" ")
 
-  function render(currentIndent: String): String = "for (\(doRenderLoopControl(currentIndent))) \(body.render(currentIndent))"
+  function render(currentIndent: String): String =
+    "for (\(doRenderLoopControl(currentIndent))) \(body.render(currentIndent))"
 }
 
 class WhenGeneratorNode extends Node {
@@ -120,13 +133,25 @@ class WhenGeneratorNode extends Node {
 
   body: ObjectBodyNode?
 
-  function render(currentIndent: String): String = "when (\(condition.render(currentIndent))) \(body.render(currentIndent))"
+  function render(currentIndent: String): String =
+    "when (\(condition.render(currentIndent))) \(body.render(currentIndent))"
 }
 
-local function doRenderInline(currentIndent: String) = "{ " + members.toList().map((m) -> m.render(currentIndent)).join("; ") + " }"
+local function doRenderInline(currentIndent: String) =
+  "{ " + members.toList().map((m) -> m.render(currentIndent)).join("; ") + " }"
 
 local function doRenderMultiline(currentIndent: String) =
   let (innerIndent = currentIndent + indent)
-    "{\n" + members.toList().map((m) -> innerIndent + m.render(innerIndent)).join("\n") + "\n\(currentIndent)}"
+  let (
+    paramList =
+      if (parameters.isEmpty)
+        ""
+      else
+        " " + parameters.toList().map((it) -> it.render(currentIndent)).join(", ") + " ->"
+  )
+    "{\(paramList)\n"
+      + members.toList().map((m) -> innerIndent + m.render(innerIndent)).join("\n")
+      + "\n\(currentIndent)}"
 
-function render(currentIndent: String) = if (renderInline) doRenderInline(currentIndent) else doRenderMultiline(currentIndent)
+function render(currentIndent: String) =
+  if (renderInline) doRenderInline(currentIndent) else doRenderMultiline(currentIndent)

--- a/packages/pkl.experimental.syntax/PklProject
+++ b/packages/pkl.experimental.syntax/PklProject
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.0"
+  version = "1.2.0"
   apiTests = import*("tests/*.pkl").keys.toListing()
 }

--- a/packages/pkl.experimental.syntax/tests/ObjectBodyNode.pkl
+++ b/packages/pkl.experimental.syntax/tests/ObjectBodyNode.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ module pkl.experimental.syntax.tests.ObjectBodyNode
 
 amends "pkl:test"
 
-import "../ObjectBodyNode.pkl"
 import "../ExpressionNode.pkl"
+import "../ObjectBodyNode.pkl"
 import "../TypeNode.pkl"
 
 local personDotName = new ExpressionNode.QualifiedMemberAccessExpressionNode {
@@ -153,6 +153,22 @@ examples {
                 propertyName { value = "conditionalProperty" }
                 assignment = new ExpressionNode.LiteralValueExpressionNode { value = true }
               }
+            }
+          }
+        }
+      }
+    }.render("")
+  }
+  ["parameters"] {
+    new ObjectBodyNode {
+      parameters {
+        new { name { value = "foo" } }
+        new { name { value = "_" } }
+        new {
+          name { value = "baz" }
+          typeAnnotation {
+            type = new TypeNode.DeclaredTypeNode {
+              name { parts { new { value = "List" } } }
             }
           }
         }

--- a/packages/pkl.experimental.syntax/tests/ObjectBodyNode.pkl-expected.pcf
+++ b/packages/pkl.experimental.syntax/tests/ObjectBodyNode.pkl-expected.pcf
@@ -38,4 +38,11 @@ examples {
     }
     """
   }
+  ["parameters"] {
+    """
+    { foo, _, baz: List ->
+    
+    }
+    """
+  }
 }


### PR DESCRIPTION
Also: fix moduleNameTest when the package name contains a quoted identifier segment