### PR TITLE
[com.github.dependabot] Add more fields to PullRequestBranchName

### DIFF
--- a/packages/com.github.dependabot/PklProject
+++ b/packages/com.github.dependabot/PklProject
@@ -17,5 +17,5 @@
 amends "../basePklProject.pkl"
 
 package {
-  version = "1.1.0"
+  version = "1.2.0"
 }

--- a/packages/com.github.dependabot/examples/pullRequestBranchName.pkl
+++ b/packages/com.github.dependabot/examples/pullRequestBranchName.pkl
@@ -1,0 +1,18 @@
+amends "../v2/Dependabot.pkl"
+
+updates {
+  new {
+    `package-ecosystem` = "npm"
+    directory = "/"
+    schedule {
+      interval = "weekly"
+    }
+    `pull-request-branch-name` {
+      template = "{prefix}/{package_manager}/{dependency}-{version}"
+      separator = "-"
+      `word-separator` = "-"
+      `branch-name-case` = "lowercase"
+      `max-length` = 80
+    }
+  }
+}

--- a/packages/com.github.dependabot/examples/pullRequestBranchName.pkl
+++ b/packages/com.github.dependabot/examples/pullRequestBranchName.pkl
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
 amends "../v2/Dependabot.pkl"
 
 updates {

--- a/packages/com.github.dependabot/tests/examples.pkl-expected.pcf
+++ b/packages/com.github.dependabot/tests/examples.pkl-expected.pcf
@@ -19,4 +19,21 @@ examples {
     
     """
   }
+  ["pullRequestBranchName.pkl"] {
+    """
+    version: 2
+    updates:
+    - package-ecosystem: npm
+      directory: /
+      pull-request-branch-name:
+        separator: '-'
+        template: '{prefix}/{package_manager}/{dependency}-{version}'
+        word-separator: '-'
+        branch-name-case: lowercase
+        max-length: 80
+      schedule:
+        interval: weekly
+    
+    """
+  }
 }

--- a/packages/com.github.dependabot/v2/Dependabot.pkl
+++ b/packages/com.github.dependabot/v2/Dependabot.pkl
@@ -284,7 +284,7 @@ class PullRequestBranchName {
   /// Default if not set: `100`
   ///
   /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#max-length>
-  `max-length`: Int(isBetween(20, 244))
+  `max-length`: Int(isBetween(20, 244))?
 }
 
 /// Schedule preferences

--- a/packages/com.github.dependabot/v2/Dependabot.pkl
+++ b/packages/com.github.dependabot/v2/Dependabot.pkl
@@ -102,7 +102,18 @@ class Update {
   /// Default if undefined: `5`
   `open-pull-requests-limit`: Int(isPositive)?
 
-  /// Pull request branch name preferences
+  /// Dependabot generates a branch for each pull request.
+  ///
+  /// Each branch name includes dependabot, as well as the name of the package manager and the dependency to be updated.
+  /// By default, these parts of the branch name are separated by a `/` symbol, for example:
+  ///
+  ///  * `dependabot/npm_and_yarn/next_js/acorn-6.4.1`
+  ///
+  /// You can customize branch names using the [`pull-request-branch-name`] option with the following parameters:
+  /// `separator`, `prefix`, `max-length`, `word-separator`, `branch-name-case`, and `template`.
+  /// All options are composable, and you can combine any of them.
+  ///
+  /// See <https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/customizing-dependabot-prs#customizing-pull-request-branch-names>
   `pull-request-branch-name`: PullRequestBranchName?
 
   /// Disable automatic rebasing. 'auto' is the default and Dependabot will rebase open pull requests
@@ -230,11 +241,50 @@ class Ignore {
 }
 
 /// Pull request branch name preferences
+/// You can combine separator, word-separator, branch-name-case, max-length, and template to produce branch names that
+/// meet your system's requirements.
+/// For example, Docker tag compatibility, Azure Container Registry naming, or Kubernetes branch length limits.
+///
+/// When [template] is set alongside other options, formatting is applied as post-processing after template rendering in
+/// this order: separator replacement, word-separator replacement, case transformation, then max-length truncation.
+///
+/// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#pull-request-branch-name-->
 class PullRequestBranchName {
   /// Change separator for PR branch name
   ///
   /// Default if undefined: `"/"`
-  separator: "-" | "_" | "/"
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#separator>
+  separator: ("-" | "_" | "/")?
+
+  /// Custom format template using placeholders.
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#template>
+  template: String(length <= 200)?
+
+  /// String prepended to the branch name.
+  ///
+  /// Default if undefined: `"dependabot"`
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#prefix-1>
+  prefix: String?
+
+  /// Character to replace underscores (`_`) in branch name content after the prefix.
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#word-separator>
+  `word-separator`: Char?
+
+  /// Apply case transformation to the branch name content after the prefix.
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#branch-name-case>
+  `branch-name-case`: ("lowercase" | "uppercase")?
+
+  /// Maximum character length of the branch name.
+  ///
+  /// Default if not set: `100`
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#max-length>
+  `max-length`: Int(isBetween(20, 244))
 }
 
 /// Schedule preferences
@@ -326,7 +376,9 @@ class MultiEcosystemGroup {
   `commit-message`: MultiEcosystemGroupCommitMessage?
 
   /// Pull request branch name preferences for the group
-  `pull-request-branch-name`: MultiEcosystemGroupPullRequestBranchName?
+  ///
+  /// See <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#pull-request-branch-name-->
+  `pull-request-branch-name`: PullRequestBranchName?
 }
 
 /// Schedule preferences for the group
@@ -359,13 +411,8 @@ class MultiEcosystemGroupCommitMessage {
   include: "scope"?
 }
 
-/// Pull request branch name preferences for the group
-class MultiEcosystemGroupPullRequestBranchName {
-  /// Change separator for PR branch name
-  ///
-  /// Default if undefined: `"/"`
-  separator: "-" | "_" | "/"
-}
+@Deprecated { replaceWith = "PullRequestBranchName"; message = "Use PullRequestBranchName instead" }
+typealias MultiEcosystemGroupPullRequestBranchName = PullRequestBranchName
 
 typealias Timezone =
   "Africa/Abidjan"

--- a/packages/pkl.github.dependabotManagedActions/PklProject
+++ b/packages/pkl.github.dependabotManagedActions/PklProject
@@ -21,7 +21,7 @@ amends "../basePklProject.pkl"
 import "DependabotManagedActions.pkl"
 
 package {
-  version = "1.1.12"
+  version = "1.1.13"
 }
 
 dependencies {

--- a/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
+++ b/packages/pkl.github.dependabotManagedActions/PklProject.deps.json
@@ -13,7 +13,7 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "local",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.1.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.2.0",
       "path": "../com.github.dependabot"
     }
   }


### PR DESCRIPTION
Also, this replaces the existing `MultiEcosystemGroupPullRequestBranchName`, as a typealias to `PullRequestBranchName`, and marks it as deprecated.

There's no actual separate structure for this on the multi-ecosystem level.

Closes #235 